### PR TITLE
feat(core): Add HttpResponse, extend HttpClient/EndpointInfo/Scanner with status-code API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <!-- JSON Processing -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/owasp/astf/core/EndpointInfo.java
+++ b/src/main/java/org/owasp/astf/core/EndpointInfo.java
@@ -9,6 +9,7 @@ public class EndpointInfo {
     private final String contentType;
     private String requestBody;
     private final boolean requiresAuthentication;
+    private String baseUrl;
 
     public EndpointInfo(String path, String method) {
         this.path = path;
@@ -43,6 +44,27 @@ public class EndpointInfo {
 
     public boolean isRequiresAuthentication() {
         return requiresAuthentication;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Returns the full URL by combining baseUrl and path.
+     * Falls back to path alone if baseUrl is not set.
+     */
+    public String getFullUrl() {
+        if (baseUrl != null && !baseUrl.isEmpty()) {
+            String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+            String p = path.startsWith("/") ? path : "/" + path;
+            return base + p;
+        }
+        return path;
     }
 
     @Override

--- a/src/main/java/org/owasp/astf/core/Scanner.java
+++ b/src/main/java/org/owasp/astf/core/Scanner.java
@@ -92,6 +92,14 @@ public class Scanner {
                 return createEmptyScanResult();
             }
 
+            // Attach base URL to all endpoints for test cases to use
+            String targetUrl = config.getTargetUrl();
+            for (EndpointInfo ep : endpoints) {
+                if (ep.getBaseUrl() == null) {
+                    ep.setBaseUrl(targetUrl);
+                }
+            }
+
             // Get applicable test cases
             List<TestCase> testCases = testCaseRegistry.getEnabledTestCases(config);
             logger.info("Running {} test cases against {} endpoints", testCases.size(), endpoints.size());

--- a/src/main/java/org/owasp/astf/core/http/HttpClient.java
+++ b/src/main/java/org/owasp/astf/core/http/HttpClient.java
@@ -155,6 +155,87 @@ public class HttpClient {
     }
 
     /**
+     * Gets the target URL from configuration.
+     *
+     * @return The configured target URL
+     */
+    public String getTargetUrl() {
+        return config.getTargetUrl();
+    }
+
+    /**
+     * Makes a GET request and returns the full response including status code.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    public HttpResponse getWithStatus(String url, Map<String, String> headers) throws IOException {
+        return executeRequestWithStatus(createRequest(url, "GET", headers, null, null));
+    }
+
+    /**
+     * Makes a POST request and returns the full response including status code.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @param contentType The content type of the request
+     * @param body The request body
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    public HttpResponse postWithStatus(String url, Map<String, String> headers, String contentType, String body) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType);
+        RequestBody requestBody = RequestBody.create(body, mediaType);
+        return executeRequestWithStatus(createRequest(url, "POST", headers, mediaType, requestBody));
+    }
+
+    /**
+     * Makes a PUT request and returns the full response including status code.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @param contentType The content type of the request
+     * @param body The request body
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    public HttpResponse putWithStatus(String url, Map<String, String> headers, String contentType, String body) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType);
+        RequestBody requestBody = RequestBody.create(body, mediaType);
+        return executeRequestWithStatus(createRequest(url, "PUT", headers, mediaType, requestBody));
+    }
+
+    /**
+     * Makes a DELETE request and returns the full response including status code.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    public HttpResponse deleteWithStatus(String url, Map<String, String> headers) throws IOException {
+        return executeRequestWithStatus(createRequest(url, "DELETE", headers, null, null));
+    }
+
+    /**
+     * Makes a PATCH request and returns the full response including status code.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @param contentType The content type of the request
+     * @param body The request body
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    public HttpResponse patchWithStatus(String url, Map<String, String> headers, String contentType, String body) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType);
+        RequestBody requestBody = RequestBody.create(body, mediaType);
+        return executeRequestWithStatus(createRequest(url, "PATCH", headers, mediaType, requestBody));
+    }
+
+    /**
      * Makes a HEAD request to the specified URL.
      *
      * @param url The target URL
@@ -275,6 +356,21 @@ public class HttpClient {
                 return response.body().string();
             }
             return "";
+        }
+    }
+
+    /**
+     * Executes a request and returns the full HTTP response including status code.
+     *
+     * @param request The HTTP request to execute
+     * @return The full HTTP response
+     * @throws IOException If the request fails
+     */
+    private HttpResponse executeRequestWithStatus(Request request) throws IOException {
+        try (Response response = client.newCall(request).execute()) {
+            String body = response.body() != null ? response.body().string() : "";
+            Map<String, List<String>> headers = extractHeaders(response);
+            return new HttpResponse(response.code(), body, headers);
         }
     }
 

--- a/src/main/java/org/owasp/astf/core/http/HttpResponse.java
+++ b/src/main/java/org/owasp/astf/core/http/HttpResponse.java
@@ -1,0 +1,55 @@
+package org.owasp.astf.core.http;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents an HTTP response including status code, headers, and body.
+ */
+public class HttpResponse {
+    private final int statusCode;
+    private final String body;
+    private final Map<String, List<String>> headers;
+
+    public HttpResponse(int statusCode, String body, Map<String, List<String>> headers) {
+        this.statusCode = statusCode;
+        this.body = body;
+        this.headers = headers;
+    }
+
+    public int getStatusCode() { return statusCode; }
+    public String getBody() { return body != null ? body : ""; }
+    public Map<String, List<String>> getHeaders() { return headers; }
+
+    public boolean isSuccess() { return statusCode >= 200 && statusCode < 300; }
+    public boolean isUnauthorized() { return statusCode == 401; }
+    public boolean isForbidden() { return statusCode == 403; }
+    public boolean isNotFound() { return statusCode == 404; }
+    public boolean isRateLimited() { return statusCode == 429; }
+    public boolean isServerError() { return statusCode >= 500; }
+    public boolean isRedirect() { return statusCode >= 300 && statusCode < 400; }
+
+    public String getHeader(String name) {
+        if (headers == null) return null;
+        List<String> values = headers.get(name);
+        if (values == null) {
+            // Case-insensitive lookup
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                if (entry.getKey() != null && entry.getKey().equalsIgnoreCase(name)) {
+                    values = entry.getValue();
+                    break;
+                }
+            }
+        }
+        return values != null && !values.isEmpty() ? values.get(0) : null;
+    }
+
+    public boolean hasHeader(String name) {
+        return getHeader(name) != null;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpResponse{statusCode=" + statusCode + ", bodyLength=" + getBody().length() + "}";
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="File" fileName="astf-scan.log"
+                     filePattern="astf-scan-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="5"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <!-- Suppress verbose OkHttp logging -->
+        <Logger name="okhttp3" level="WARN" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="okio" level="WARN" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+
+        <!-- ASTF framework loggers -->
+        <Logger name="org.owasp.astf" level="INFO" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <Root level="WARN">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Summary

Foundational infrastructure that all subsequent PRs in this series build on. Replaces fragile string-body vulnerability detection with HTTP status-code-based detection.

- **`HttpResponse`** — new value object with `isSuccess()`, `isUnauthorized()`, `isForbidden()`, `isRateLimited()`, `isServerError()`, `getHeader()`, `hasHeader()`
- **`HttpClient`** — new `getWithStatus()`, `postWithStatus()`, `putWithStatus()`, `deleteWithStatus()`, `patchWithStatus()` returning full `HttpResponse`
- **`EndpointInfo`** — new `getBaseUrl()` / `setBaseUrl()` / `getFullUrl()` so test cases build absolute URLs without knowing the scan target
- **`Scanner`** — injects `baseUrl` on every endpoint before dispatching to test cases
- **`log4j2.xml`** — console + rolling-file appenders; OkHttp suppressed at WARN
- **`pom.xml`** — removes duplicate `jackson-databind` dependency

## PR Series — merge in order

| # | Branch | Closes |
|---|--------|--------|
| **1 — this PR** | `feat/core-infrastructure` | — |
| 2 | `feat/cli-and-reporting` | #45 |
| 3 | `feat/owasp-test-cases` | — |
| 4 | `feat/integrations` | #31, #37 |
| 5 | `feat/core-unit-tests` | #27, #28, #29, #30 |
| 6 | `feat/testcase-unit-tests` | #32, #33, #35, #36 |

## Test plan
- [ ] `mvn compile` passes with no warnings
- [ ] Existing tests continue to pass
- [ ] `HttpResponse` predicates return correct values for 200/401/403/429/500

🤖 Generated with [Claude Code](https://claude.com/claude-code)