### PR TITLE
feat: Manual endpoint input — --endpoints-file flag, inline YAML block, endpointsFile key

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ See [`docs/examples/scan-config.yaml`](docs/examples/scan-config.yaml) for the f
 ```
 Usage: astf [-hvV] [--no-discovery] [--api-key=<apiKey>]
             [--api-key-header=<apiKeyHeader>] [-c=<configFile>]
-            [--exclude-tests=<ids>] [-f=<format>] [-o=<outputFile>]
-            [--password=<password>] [--proxy=<proxyUrl>] [-t=<threads>]
-            [--test-cases=<ids>] [--timeout=<minutes>] [--token=<bearerToken>]
-            [-u=<targetUrl>] [--username=<username>] [--header=<Key:Value>]...
+            [--endpoints-file=<file>] [--exclude-tests=<ids>] [-f=<format>]
+            [-o=<outputFile>] [--password=<password>] [--proxy=<proxyUrl>]
+            [-t=<threads>] [--test-cases=<ids>] [--timeout=<minutes>]
+            [--token=<bearerToken>] [-u=<targetUrl>] [--username=<username>]
+            [--header=<Key:Value>]...
 ```
 
 | Flag | Short | Description | Default |
@@ -144,6 +145,7 @@ Usage: astf [-hvV] [--no-discovery] [--api-key=<apiKey>]
 | `--password` | | Basic auth password | — |
 | `--header` | | Extra header `Key:Value` (repeatable) | — |
 | `--proxy` | | Proxy URL e.g. `http://proxy:8080` | — |
+| `--endpoints-file` | | File of endpoints to test (`METHOD /path` per line). Skips discovery. | — |
 | `--threads` | `-t` | Concurrent threads | `10` |
 | `--timeout` | | Scan timeout in minutes | `30` |
 | `--test-cases` | | Comma-separated test case IDs to run | all |
@@ -152,6 +154,30 @@ Usage: astf [-hvV] [--no-discovery] [--api-key=<apiKey>]
 | `--verbose` | `-v` | Verbose output | false |
 | `--version` | `-V` | Print version | — |
 | `--help` | `-h` | Show help | — |
+
+### Endpoint Input Precedence
+
+When multiple endpoint sources are configured, ASTF uses this order (highest wins):
+
+| Priority | Source | How |
+|---|---|---|
+| 1 | `--endpoints-file` CLI flag | Overrides everything |
+| 2 | `endpoints:` inline YAML block | In config file |
+| 3 | `endpointsFile:` YAML key | In config file |
+| 4 | Automatic discovery | OpenAPI probing + common paths |
+| 5 | Fallback hardcoded paths | When discovery finds nothing |
+
+```bash
+# Scan only specific endpoints from a file
+java -jar astf-v1.0.0-beta.jar -u https://api.example.com \
+  --endpoints-file my-endpoints.txt --token "TOKEN"
+
+# my-endpoints.txt format:
+# GET  /api/v1/users
+# GET  /api/v1/users/{id}
+# POST /api/v1/users
+# DELETE /api/v1/users/{id}
+```
 
 ### Exit Codes
 

--- a/docs/examples/scan-config.yaml
+++ b/docs/examples/scan-config.yaml
@@ -9,20 +9,32 @@ target:
   # Base URL of the API under test (trailing slash is added automatically).
   url: "https://api.example.com"
 
-  # Explicitly list endpoints to test instead of relying on auto-discovery.
-  # Each entry requires at minimum a path and HTTP method.
-  # endpoints:
-  #   - path: "/api/v1/users"
-  #     method: "GET"
-  #     requiresAuthentication: true
-  #     contentType: "application/json"
-  #   - path: "/api/v1/users/{id}"
-  #     method: "PUT"
-  #     requiresAuthentication: true
-
   # Enable automatic endpoint discovery (OpenAPI spec, common paths, etc.).
-  # Set to false if you provide an explicit endpoints list above.
+  # Set to false if you provide an explicit endpoints list below.
   discoveryEnabled: true
+
+
+# ── Manual endpoint input (all three methods are optional — use at most one) ──
+#
+# OPTION A — Inline endpoint list (highest config-file precedence)
+# Discovery is skipped automatically when endpoints are provided here.
+# endpoints:
+#   - path: "/api/v1/users"
+#     method: "GET"
+#   - path: "/api/v1/users/{id}"
+#     method: "GET"
+#   - path: "/api/v1/users"
+#     method: "POST"
+#   - path: "/api/v1/users/{id}"
+#     method: "DELETE"
+#
+# OPTION B — Load endpoints from an external text file (lower precedence than inline)
+# File format: one endpoint per line — METHOD /path
+# Lines starting with # are comments; blank lines are ignored.
+# endpointsFile: "/path/to/endpoints.txt"
+#
+# OPTION C — CLI flag (highest overall precedence, overrides both options above)
+# Pass --endpoints-file /path/to/endpoints.txt when running astf
 
   # URL path patterns to skip during scanning (regex supported).
   excludePatterns:

--- a/src/main/java/org/owasp/astf/cli/ASTFCli.java
+++ b/src/main/java/org/owasp/astf/cli/ASTFCli.java
@@ -28,25 +28,33 @@ import picocli.CommandLine.Option;
  * Usage: astf [OPTIONS]
  *
  * Options:
- *   -u, --url           Target API base URL (required)
- *   -c, --config        Path to configuration file (YAML/JSON/properties)
- *   -o, --output        Output file path
- *   -f, --format        Output format: JSON (default), XML, HTML, SARIF
- *   -t, --threads       Number of concurrent threads (default: 10)
- *   --token             Bearer token for authentication
- *   --api-key           API key for authentication
- *   --api-key-header    Header name for API key (default: X-API-Key)
- *   --username          Basic auth username
- *   --password          Basic auth password
- *   --header            Additional headers in Key:Value format (repeatable)
- *   --proxy             Proxy URL (e.g., http://proxy:8080)
- *   --no-discovery      Disable automatic endpoint discovery
- *   --test-cases        Comma-separated list of test case IDs to run
- *   --exclude-tests     Comma-separated list of test case IDs to skip
- *   --timeout           Scan timeout in minutes (default: 30)
- *   --verbose, -v       Enable verbose output
- *   --version, -V       Print version and exit
- *   --help, -h          Show help
+ *   -u, --url              Target API base URL (required)
+ *   -c, --config           Path to configuration file (YAML/JSON/properties)
+ *   -o, --output           Output file path
+ *   -f, --format           Output format: JSON (default), XML, HTML, SARIF
+ *   -t, --threads          Number of concurrent threads (default: 10)
+ *   --token                Bearer token for authentication
+ *   --api-key              API key for authentication
+ *   --api-key-header       Header name for API key (default: X-API-Key)
+ *   --username             Basic auth username
+ *   --password             Basic auth password
+ *   --header               Additional headers in Key:Value format (repeatable)
+ *   --proxy                Proxy URL (e.g., http://proxy:8080)
+ *   --endpoints-file       Path to a file containing endpoints to test (one per line: METHOD /path)
+ *   --no-discovery         Disable automatic endpoint discovery
+ *   --test-cases           Comma-separated list of test case IDs to run
+ *   --exclude-tests        Comma-separated list of test case IDs to skip
+ *   --timeout              Scan timeout in minutes (default: 30)
+ *   --verbose, -v          Enable verbose output
+ *   --version, -V          Print version and exit
+ *   --help, -h             Show help
+ *
+ * Endpoint input precedence (highest to lowest):
+ *   1. --endpoints-file (CLI flag)
+ *   2. endpoints (inline YAML block in config file)
+ *   3. endpointsFile (YAML config key)
+ *   4. Automatic discovery
+ *   5. Fallback hardcoded endpoints
  * </pre>
  */
 @Command(
@@ -95,6 +103,11 @@ public class ASTFCli implements Callable<Integer> {
 
     @Option(names = {"--proxy"}, description = "Proxy URL (e.g., http://proxy:8080)")
     private String proxyUrl;
+
+    @Option(names = {"--endpoints-file"},
+            description = "Path to a file of endpoints to test, one per line (format: METHOD /path). " +
+                          "Skips automatic discovery. Lines starting with # are ignored.")
+    private String endpointsFile;
 
     @Option(names = {"--no-discovery"}, description = "Disable automatic endpoint discovery")
     private boolean noDiscovery;
@@ -206,6 +219,19 @@ public class ASTFCli implements Callable<Integer> {
         }
         if (disabledTestCases != null) {
             config.setDisabledTestCaseIds(List.of(disabledTestCases.split(",\\s*")));
+        }
+
+        // Endpoint input — CLI --endpoints-file takes highest precedence (REQ-001, REQ-006)
+        // Lower-precedence sources (inline endpoints, endpointsFile YAML key) are resolved
+        // during config file parsing in ConfigLoader.parseJsonConfig().
+        if (endpointsFile != null) {
+            ConfigLoader loader = new ConfigLoader();
+            List<EndpointInfo> manualEndpoints = loader.loadEndpointsFromFile(endpointsFile);
+            config.setEndpoints(manualEndpoints);
+            logger.info("Using {} user-provided endpoints from {} — skipping automatic discovery",
+                    manualEndpoints.size(), endpointsFile);
+            System.out.printf("Endpoints: %d loaded from %s (discovery skipped)%n",
+                    manualEndpoints.size(), endpointsFile);
         }
 
         // Add API key header if API key is configured but no header set yet

--- a/src/main/java/org/owasp/astf/core/config/ConfigLoader.java
+++ b/src/main/java/org/owasp/astf/core/config/ConfigLoader.java
@@ -240,6 +240,41 @@ public class ConfigLoader {
             }
         }
 
+        // Endpoint input — REQ-002: endpointsFile YAML key
+        // REQ-006 precedence: endpointsFile < inline endpoints (inline wins if both present)
+        if (root.has("endpointsFile")) {
+            String filePath = root.get("endpointsFile").asText();
+            try {
+                List<EndpointInfo> fileEndpoints = loadEndpointsFromFile(filePath);
+                config.setEndpoints(fileEndpoints);
+                logger.info("Loaded {} endpoints from endpointsFile: {}", fileEndpoints.size(), filePath);
+            } catch (IOException e) {
+                logger.warn("Could not load endpointsFile '{}': {}", filePath, e.getMessage());
+            }
+        }
+
+        // REQ-003: inline endpoints array — takes precedence over endpointsFile (REQ-006)
+        if (root.has("endpoints") && root.get("endpoints").isArray()) {
+            List<EndpointInfo> inlineEndpoints = new ArrayList<>();
+            root.get("endpoints").forEach(node -> {
+                String path = node.has("path") ? node.get("path").asText() : null;
+                if (path == null || path.isBlank()) {
+                    logger.warn("Skipping inline endpoint with missing or blank path: {}", node);
+                    return;
+                }
+                String method = node.has("method") ? node.get("method").asText().toUpperCase() : "GET";
+                inlineEndpoints.add(new EndpointInfo(path, method));
+            });
+            if (!inlineEndpoints.isEmpty()) {
+                if (!config.getEndpoints().isEmpty()) {
+                    logger.warn("Both 'endpoints' (inline) and 'endpointsFile' are specified — " +
+                                "inline endpoints take precedence (endpointsFile ignored)");
+                }
+                config.setEndpoints(inlineEndpoints);
+                logger.info("Loaded {} inline endpoints from config", inlineEndpoints.size());
+            }
+        }
+
         // Test case configuration
         if (root.has("enableTestCases") && root.get("enableTestCases").isArray()) {
             JsonNode enableTests = root.get("enableTestCases");

--- a/src/test/java/org/owasp/astf/core/config/ConfigLoaderTest.java
+++ b/src/test/java/org/owasp/astf/core/config/ConfigLoaderTest.java
@@ -229,6 +229,124 @@ class ConfigLoaderTest {
     }
 
     // -------------------------------------------------------------------------
+    // REQ-002: endpointsFile YAML key
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("REQ-002: Should load endpoints via endpointsFile YAML key")
+    void testLoadEndpointsViaYamlKey(@TempDir Path tempDir) throws IOException {
+        String endpointsContent = """
+                GET /api/v1/users
+                POST /api/v1/users
+                DELETE /api/v1/users/{id}
+                """;
+        Path endpointsFile = tempDir.resolve("endpoints.txt");
+        Files.writeString(endpointsFile, endpointsContent);
+
+        String yaml = "targetUrl: https://api.example.com\n" +
+                      "endpointsFile: " + endpointsFile.toString().replace("\\", "/") + "\n";
+        Path configFile = tempDir.resolve("config.yaml");
+        Files.writeString(configFile, yaml);
+
+        ScanConfig config = loader.loadFromFile(configFile.toString());
+
+        assertEquals(3, config.getEndpoints().size());
+        assertEquals("GET",  config.getEndpoints().get(0).getMethod());
+        assertEquals("/api/v1/users", config.getEndpoints().get(0).getPath());
+        assertEquals("POST", config.getEndpoints().get(1).getMethod());
+        assertEquals("DELETE", config.getEndpoints().get(2).getMethod());
+    }
+
+    @Test
+    @DisplayName("REQ-002: Should warn and continue when endpointsFile path does not exist")
+    void testMissingEndpointsFileYamlKey(@TempDir Path tempDir) throws IOException {
+        String yaml = """
+                targetUrl: https://api.example.com
+                endpointsFile: /nonexistent/endpoints.txt
+                """;
+        Path configFile = tempDir.resolve("config.yaml");
+        Files.writeString(configFile, yaml);
+
+        // Should not throw — logs a warning and continues with empty endpoint list
+        ScanConfig config = loader.loadFromFile(configFile.toString());
+        assertNotNull(config);
+        assertTrue(config.getEndpoints().isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // REQ-003: inline endpoints YAML block
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("REQ-003: Should load inline endpoints array from YAML config")
+    void testLoadInlineEndpoints(@TempDir Path tempDir) throws IOException {
+        String yaml = """
+                targetUrl: https://api.example.com
+                endpoints:
+                  - path: /api/v1/users
+                    method: GET
+                  - path: /api/v1/users/{id}
+                    method: DELETE
+                  - path: /api/v1/orders
+                """;
+        Path configFile = tempDir.resolve("config.yaml");
+        Files.writeString(configFile, yaml);
+
+        ScanConfig config = loader.loadFromFile(configFile.toString());
+
+        assertEquals(3, config.getEndpoints().size());
+        assertEquals("GET",    config.getEndpoints().get(0).getMethod());
+        assertEquals("/api/v1/users", config.getEndpoints().get(0).getPath());
+        assertEquals("DELETE", config.getEndpoints().get(1).getMethod());
+        // method defaults to GET when omitted
+        assertEquals("GET",    config.getEndpoints().get(2).getMethod());
+        assertEquals("/api/v1/orders", config.getEndpoints().get(2).getPath());
+    }
+
+    @Test
+    @DisplayName("REQ-003: Inline endpoints entry without path should be skipped")
+    void testInlineEndpointMissingPath(@TempDir Path tempDir) throws IOException {
+        String yaml = """
+                targetUrl: https://api.example.com
+                endpoints:
+                  - path: /api/v1/users
+                    method: GET
+                  - method: POST
+                """;
+        Path configFile = tempDir.resolve("config.yaml");
+        Files.writeString(configFile, yaml);
+
+        ScanConfig config = loader.loadFromFile(configFile.toString());
+
+        // Entry without path is skipped; only the valid one is loaded
+        assertEquals(1, config.getEndpoints().size());
+        assertEquals("/api/v1/users", config.getEndpoints().get(0).getPath());
+    }
+
+    @Test
+    @DisplayName("REQ-006: Inline endpoints take precedence over endpointsFile when both are set")
+    void testInlineEndpointsTakePrecedenceOverEndpointsFile(@TempDir Path tempDir) throws IOException {
+        String fileContent = "GET /from-file\n";
+        Path endpointsFile = tempDir.resolve("endpoints.txt");
+        Files.writeString(endpointsFile, fileContent);
+
+        String yaml = "targetUrl: https://api.example.com\n" +
+                      "endpointsFile: " + endpointsFile.toString().replace("\\", "/") + "\n" +
+                      "endpoints:\n" +
+                      "  - path: /from-inline\n" +
+                      "    method: POST\n";
+        Path configFile = tempDir.resolve("config.yaml");
+        Files.writeString(configFile, yaml);
+
+        ScanConfig config = loader.loadFromFile(configFile.toString());
+
+        // Inline wins
+        assertEquals(1, config.getEndpoints().size());
+        assertEquals("/from-inline", config.getEndpoints().get(0).getPath());
+        assertEquals("POST", config.getEndpoints().get(0).getMethod());
+    }
+
+    // -------------------------------------------------------------------------
     // System properties
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **REQ-001** — `--endpoints-file` CLI flag: load endpoints from a text file (`METHOD /path` per line), skipping discovery automatically
- **REQ-002** — `endpointsFile:` YAML config key: same as above but specified in the config file
- **REQ-003** — Inline `endpoints:` array in YAML config: define endpoints directly without a separate file
- **REQ-004** — Skip discovery when endpoints provided: already implemented in `Scanner.java` (no change needed)
- **REQ-006** — Precedence order enforced: CLI flag > inline YAML > endpointsFile key > auto-discovery > fallback

## What changed

| File | Change |
|---|---|
| `ASTFCli.java` | Added `--endpoints-file` flag; wires `ConfigLoader.loadEndpointsFromFile()` which previously existed but was never called |
| `ConfigLoader.parseJsonConfig()` | Added parsing for `endpointsFile` YAML key and inline `endpoints` array (both were silently ignored before) |
| `ConfigLoaderTest.java` | 5 new tests covering REQ-002, REQ-003, and REQ-006 precedence |
| `docs/examples/scan-config.yaml` | Documents all three endpoint input methods with examples |
| `README.md` | Added `--endpoints-file` to CLI reference table + new Endpoint Input Precedence section |

## Usage examples

**CLI flag** (highest precedence):
```bash
java -jar astf-v1.0.0-beta.jar -u https://api.example.com \
  --endpoints-file my-endpoints.txt --token "TOKEN"
```

**endpoints.txt format:**
```
# Lines starting with # are ignored
GET  /api/v1/users
GET  /api/v1/users/{id}
POST /api/v1/users
DELETE /api/v1/users/{id}
```

**YAML inline:**
```yaml
targetUrl: https://api.example.com
endpoints:
  - path: /api/v1/users
    method: GET
  - path: /api/v1/users/{id}
    method: DELETE
```

**YAML file reference:**
```yaml
targetUrl: https://api.example.com
endpointsFile: /path/to/endpoints.txt
```

## Precedence order

1. `--endpoints-file` CLI flag
2. `endpoints:` inline YAML block
3. `endpointsFile:` YAML key
4. Automatic discovery
5. Fallback hardcoded endpoints

## Test results

Tests run: **229**, Failures: 0, Errors: 0, Skipped: 0 (224 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)