### PR TITLE
ci: add explicit workflow-level permissions to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Robo-Reviewer (CI)
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hardens `ci.yml` by declaring the minimum `GITHUB_TOKEN` scope it needs.

The workflow already runs read-only (checkout + CI). Without an explicit `permissions:` block, the run inherits the repo's default token permission. On older repositories that default is permissive read-write, which means any action invoked inside the job could in principle use the token to commit back to the branch, open issues, or modify releases. Whether that ever happens in practice depends on the supply chain of every action used in the workflow.

The fix: add `permissions: contents: read` at the top level. That tightens the scope to exactly what the workflow consumes. If a future step adds a genuinely write-scoped operation, the override can be added at the job level with explicit justification.

References:
- GitHub token hardening guide: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- OpenSSF Scorecard (Token-Permissions)
- the tj-actions/changed-files supply-chain incident from March 2025

YAML validated with `yaml.safe_load`. No other edits in the PR.
