### PR TITLE
fix: weak-credential check now inspects response body, not just HTTP status

### DIFF
--- a/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
@@ -50,6 +50,19 @@ public class BrokenAuthenticationTestCase implements TestCase {
             "000000", "123456", "111111", "999999", "654321", "112233"
     );
 
+    // Some APIs return HTTP 200 on both success AND failure, carrying the real result only in
+    // the response body (e.g. VAmPI: {"status":"fail","message":"..."} with a 200 status).
+    // A 2xx status code alone is therefore not sufficient evidence of a successful auth bypass —
+    // it must also be checked against these common failure markers in the body.
+    private static final List<String> AUTH_FAILURE_BODY_MARKERS = List.of(
+            "\"status\":\"fail\"", "\"status\": \"fail\"",
+            "\"success\":false", "\"success\": false",
+            "\"authenticated\":false", "\"authenticated\": false",
+            "incorrect", "invalid credentials", "invalid username", "invalid password",
+            "authentication failed", "login failed", "unauthorized", "access denied",
+            "wrong password", "not correct", "does not match"
+    );
+
     @Override
     public String getId() {
         return "ASTF-API2-2023";
@@ -109,6 +122,24 @@ public class BrokenAuthenticationTestCase implements TestCase {
         return TWO_FA_PATH_PATTERNS.stream().anyMatch(path::contains);
     }
 
+    /**
+     * A 2xx status code alone does not prove an authentication attempt succeeded — some APIs
+     * (e.g. VAmPI) return HTTP 200 for both successful and failed logins, with the real outcome
+     * only in the response body. This checks the status code AND scans the body for common
+     * failure markers before treating the response as a genuine success.
+     */
+    private boolean looksLikeAuthSuccess(HttpResponse response) {
+        if (response == null || !response.isSuccess()) {
+            return false;
+        }
+        String body = response.getBody();
+        if (body == null || body.isBlank()) {
+            return true; // no body to contradict the status code
+        }
+        String lower = body.toLowerCase();
+        return AUTH_FAILURE_BODY_MARKERS.stream().noneMatch(lower::contains);
+    }
+
     private List<Finding> testWeakAuthentication(EndpointInfo endpoint, HttpClient httpClient) {
         List<Finding> findings = new ArrayList<>();
 
@@ -132,7 +163,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                         creds.get("username"), creds.get("password"));
                 HttpResponse response = httpClient.postWithStatus(fullUrl, Map.of(), "application/json", body);
 
-                if (response.isSuccess()) {
+                if (looksLikeAuthSuccess(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "Weak Default Credentials Accepted",
@@ -201,7 +232,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 }
             }
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 // A 2xx response without auth headers indicates missing authentication controls
                 findings.add(buildMissingAuthFinding(endpoint));
             }
@@ -263,7 +294,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 default       -> httpClient.getWithStatus(fullUrl, noneAlgHeaders);
             };
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 Finding finding = new Finding(
                         UUID.randomUUID().toString(),
                         "JWT 'none' Algorithm Accepted",
@@ -373,7 +404,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 default       -> httpClient.getWithStatus(fullUrl, expiredJwtHeaders);
             };
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 Finding finding = new Finding(
                         UUID.randomUUID().toString(),
                         "Expired JWT Token Accepted",
@@ -490,7 +521,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 String body = String.format("{\"code\":\"%s\"}", code);
                 HttpResponse response = httpClient.postWithStatus(fullUrl, Map.of(), "application/json", body);
 
-                if (response != null && response.isSuccess()) {
+                if (looksLikeAuthSuccess(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "2FA/MFA Bypass — Weak OTP Code Accepted",

--- a/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
@@ -254,6 +254,37 @@ class BrokenAuthenticationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should NOT flag weak credentials when HTTP 200 body indicates the login actually failed (VAmPI-style false positive)")
+    void testWeakCredentialsNoFalsePositiveOn200WithFailureBody() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/login", "POST", "application/json", "{}", true);
+
+        // Mirrors VAmPI: login always returns HTTP 200, real result is in the body.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"status\": \"fail\", \"message\": \"Username or Password Incorrect!\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> "Weak Default Credentials Accepted".equals(f.getTitle())),
+                "Should not report weak credentials accepted when the response body says the login failed");
+        assertTrue(findings.stream().noneMatch(f -> "2FA/MFA Bypass — Weak OTP Code Accepted".equals(f.getTitle())),
+                "Should not report OTP bypass when the response body says the attempt failed");
+    }
+
+    @Test
+    @DisplayName("Should still flag weak credentials when HTTP 200 body has no failure indicator")
+    void testWeakCredentialsStillDetectedOnGenuineSuccess() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/login", "POST", "application/json", "{}", true);
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"auth_token\": \"abc123\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> "Weak Default Credentials Accepted".equals(f.getTitle())),
+                "Should still report weak credentials accepted on a genuine 200 success with no failure markers");
+    }
+
+    @Test
     @DisplayName("Should detect sensitive tokens exposed in URL query parameters")
     void testTokenInUrl() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/data?token=abc123secret", "GET", "application/json", null, false);


### PR DESCRIPTION
Fixes #70

## Summary
`BrokenAuthenticationTestCase` flagged a CRITICAL "Weak Default Credentials Accepted" finding whenever a login attempt returned HTTP 2xx, without checking whether the response body actually indicated success. Some APIs (e.g. VAmPI) return HTTP 200 for both successful and failed logins, with the real result only in the JSON body — producing a false CRITICAL.

## Reproduction
Scanned [VAmPI](https://github.com/erev0s/VAmPI) in both `vulnerable=1` and `vulnerable=0` modes. Both flagged `POST /users/v1/login` as accepting `admin/admin`. Manually replaying the exact request:
```
$ curl -s -X POST http://127.0.0.1:5001/users/v1/login -d '{"username":"admin","password":"admin"}'
{ "status": "fail", "message": "Username or Password Incorrect!"}
```
HTTP 200, but the login clearly failed.

## Fix
Adds `looksLikeAuthSuccess()`, which requires the response body to be free of common failure markers (`"status":"fail"`, `incorrect`, `invalid credentials`, `unauthorized`, ...) before trusting a 2xx status as a real success. Applied consistently to the weak-credential, missing-auth, JWT-none, expired-JWT, and 2FA-bypass checks in the same file, which all shared the identical status-code-only pattern.

## Verification
- Re-ran against VAmPI vulnerable and secure instances after the fix: the false CRITICAL is gone in both (0, was 1); a failed weak-credential attempt now correctly falls through to the existing "Authentication Endpoint Requires Manual Review" (MEDIUM) finding instead.
- New regression tests added: one confirming the VAmPI-style 200-with-failure-body is no longer flagged, one confirming a genuine 200-success is still flagged.
- Full suite passes (241 tests).

## Test plan
- [x] `mvn test` passes
- [x] Re-scanned VAmPI vulnerable/secure with the fixed jar — false CRITICAL confirmed gone, no loss of real findings