### PR TITLE
fix: GraphQL depth-limit probe uses real schema fields instead of guessed names

### DIFF
--- a/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
@@ -65,13 +65,20 @@ public class GraphQLSecurityTestCase implements TestCase {
     private static final String SUGGESTION_PROBE_QUERY =
             "{\"query\":\"{__typenme}\"}";   // intentional typo: __typenme
 
-    // Deeply nested query designed to trigger resource exhaustion
-    private static final String DEEP_QUERY;
+    // Deeply nested query designed to trigger resource exhaustion.
+    //
+    // Built from __Type.ofType — a self-referencing field that is part of the mandatory
+    // introspection schema every spec-compliant GraphQL server exposes — rather than guessed
+    // application field names. A query built from placeholder names like "{a{b{c{...}}}}"
+    // fails schema validation (HTTP 400 "Cannot query field") on any real schema before depth
+    // is ever assessed; chaining ofType always resolves to a real, deeply-nestable field.
+    static final String DEEP_QUERY;
     static {
-        StringBuilder sb = new StringBuilder("{\"query\":\"{ a { b { c { d { e { f { g { h { i { j");
-        for (int i = 0; i < 10; i++) sb.append(" }");
-        sb.append("}}}\"}");
-        DEEP_QUERY = sb.toString();
+        StringBuilder chain = new StringBuilder("kind name");
+        for (int i = 0; i < 12; i++) {
+            chain = new StringBuilder("kind name ofType{" + chain + "}");
+        }
+        DEEP_QUERY = "{\"query\":\"{__schema{types{" + chain + "}}}\"}";
     }
 
     // Batch query — three introspection operations in one HTTP call
@@ -122,6 +129,24 @@ public class GraphQLSecurityTestCase implements TestCase {
     }
 
     // ── Helper: is this endpoint a GraphQL endpoint? ──────────────────────────
+
+    /**
+     * GraphQL servers return HTTP 200 for both successful queries AND validation/execution
+     * errors — per spec, errors are reported in the response body's {@code "errors"} array,
+     * never via HTTP status. A 2xx status therefore does not by itself prove a query was
+     * accepted; the body must also contain real {@code "data"} and be free of an
+     * {@code "errors"} entry (e.g. a depth-limit or schema-validation rejection).
+     */
+    boolean isAcceptedGraphQLQuery(HttpResponse response) {
+        if (response == null || !response.isSuccess()) {
+            return false;
+        }
+        String body = response.getBody();
+        if (body == null || body.isBlank() || !body.contains("\"data\"")) {
+            return false;
+        }
+        return !body.contains("\"errors\"");
+    }
 
     boolean isGraphQLEndpoint(EndpointInfo endpoint) {
         String path = endpoint.getPath().toLowerCase();
@@ -175,9 +200,13 @@ public class GraphQLSecurityTestCase implements TestCase {
             HttpResponse response = httpClient.postWithStatus(
                     endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, INTROSPECTION_QUERY);
 
-            if (response != null && response.isSuccess()) {
+            if (isAcceptedGraphQLQuery(response)) {
                 String body = response.getBody();
-                if (body != null && body.contains("__schema")) {
+                // "queryType" only appears in a genuine introspection result (it's a field we
+                // explicitly requested) — unlike a bare "__schema" substring check, it can't be
+                // accidentally matched by an error message such as
+                // `"Cannot query field \"__schema\" on type \"Query\"."` when introspection is disabled.
+                if (body != null && body.contains("queryType")) {
                     Finding f = new Finding(
                             UUID.randomUUID().toString(),
                             "GraphQL Introspection Enabled in Production",
@@ -254,8 +283,9 @@ public class GraphQLSecurityTestCase implements TestCase {
             HttpResponse response = httpClient.postWithStatus(
                     endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, DEEP_QUERY);
 
-            if (response != null && response.isSuccess()) {
-                // The server accepted the deeply nested query without rejecting it
+            if (isAcceptedGraphQLQuery(response)) {
+                // The server resolved the deeply nested query (real "data", no "errors") instead
+                // of rejecting it — depth limiting is not enforced.
                 Finding f = new Finding(
                         UUID.randomUUID().toString(),
                         "GraphQL Query Depth Limit Not Enforced",
@@ -270,7 +300,7 @@ public class GraphQLSecurityTestCase implements TestCase {
                         "Recommended maximum depth: 5-10 levels."
                 );
                 f.setEvidence("Server returned HTTP " + response.getStatusCode() +
-                        " for a query nested 10+ levels deep");
+                        " with resolved data (no errors) for a query nested 12+ levels deep via __Type.ofType");
                 findings.add(f);
             }
         } catch (Exception e) {

--- a/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
@@ -3,6 +3,7 @@ package org.owasp.astf.testcases;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.owasp.astf.core.EndpointInfo;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -92,6 +94,22 @@ class GraphQLSecurityTestCaseTest {
         assertTrue(findings.isEmpty(), "No finding when introspection is disabled");
     }
 
+    @Test
+    @DisplayName("No false positive when a schema-validation error message happens to mention '__schema'")
+    void testIntrospectionDisabledNoFalsePositiveOnErrorMessageMentioningSchema() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        // Real-world error text from servers with introspection disabled — the literal
+        // substring "__schema" appears here even though introspection is OFF, which a naive
+        // body.contains("__schema") check would misread as introspection being enabled.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"errors\":[{\"message\":\"Cannot query field \\\"__schema\\\" on type \\\"Query\\\".\"}]}"));
+
+        List<Finding> findings = testCase.testIntrospectionEnabled(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(), "Should not flag introspection when the response is an error, even if it mentions __schema");
+    }
+
     // ── field suggestion leakage ──────────────────────────────────────────────
 
     @Test
@@ -153,6 +171,28 @@ class GraphQLSecurityTestCaseTest {
         List<Finding> findings = testCase.testQueryDepthAttack(endpoint, httpClient);
 
         assertTrue(findings.isEmpty(), "No finding when depth limit is enforced");
+    }
+
+    @Test
+    @DisplayName("Depth probe is built from real, always-valid schema fields, not guessed placeholder names")
+    void testDeepQueryUsesRealSchemaFields() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"data\":{\"__schema\":{\"types\":[]}}}"));
+
+        testCase.testQueryDepthAttack(endpoint, httpClient);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(httpClient).postWithStatus(anyString(), anyMap(), anyString(), bodyCaptor.capture());
+
+        String sentQuery = bodyCaptor.getValue();
+        // __Type.ofType is part of every spec-mandated introspection schema, so nesting it
+        // reaches real depth resolution instead of failing schema validation the way guessed
+        // placeholder field names ("a", "b", "c", ...) would on any real GraphQL server.
+        assertTrue(sentQuery.contains("ofType"), "Deep query should chain the always-valid __Type.ofType field");
+        assertFalse(sentQuery.matches(".*\\{\\s*a\\s*\\{\\s*b\\s*\\{.*"),
+                "Deep query should not use guessed placeholder field names like a/b/c");
     }
 
     // ── batch query ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #71

## Summary
The query-depth-limit check sent a hardcoded deeply-nested query built from placeholder field names (`a`, `b`, `c`, ...). Every real GraphQL schema rejects that at schema validation (HTTP 400 "Cannot query field") before depth is ever assessed, so the check could never produce a true positive against any real target.

## Reproduction
Scanned [DVGA](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application). Introspection and batch-query-abuse were correctly detected, but no depth-limit finding was ever produced. Replaying the exact probe by hand:
```
$ curl -s -X POST http://127.0.0.1:5000/graphql -d '{"query":"{a{b{c{d{e{f{g{h{i{j}}}}}}}}}}"}'
{"errors":[{"message":"Cannot query field \"a\" on type \"Query\"."}]}
```

## Fix
Rebuilds the probe from `__Type.ofType`, a self-referencing field mandated by the GraphQL introspection spec on every compliant server, so it reaches real depth resolution instead of failing validation.

Also fixes a latent sibling bug in the introspection check: it accepted any 2xx response containing the substring `"__schema"`, but a disabled-introspection error message (`Cannot query field "__schema"...`) matches that same substring, which would have caused a false "introspection enabled" finding. Now requires a real `"data"` body with no `"errors"`.

## Verification
- Re-ran against DVGA after the fix: `"GraphQL Query Depth Limit Not Enforced"` (MEDIUM) now fires correctly. Manually replayed the new probe and confirmed a genuine `"data"` response with no `"errors"`.
- New regression tests: probe payload asserted to use `ofType` chaining (not guessed names) via an `ArgumentCaptor`, and the introspection check asserted to not false-positive on an error message that mentions `__schema`.
- Full suite passes (241 tests).

## Test plan
- [x] `mvn test` passes
- [x] Re-scanned DVGA with the fixed jar — depth-limit finding now fires, manually verified as accurate