### PR TITLE
fix: gRPC detection can now connect to real (h2c) gRPC servers

### DIFF
--- a/src/main/java/org/owasp/astf/core/http/HttpClient.java
+++ b/src/main/java/org/owasp/astf/core/http/HttpClient.java
@@ -24,6 +24,7 @@ import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -50,6 +51,9 @@ public class HttpClient {
     private final ScanConfig config;
     private final Map<String, String> defaultHeaders;
     private final Map<String, List<Cookie>> cookieStore = new HashMap<>();
+
+    // Lazily-built client for HTTP/2 cleartext (h2c) prior-knowledge requests — see postH2c().
+    private volatile OkHttpClient h2cClient;
 
     /**
      * Creates a new HTTP client with the specified configuration.
@@ -152,6 +156,55 @@ public class HttpClient {
         MediaType mediaType = MediaType.parse(contentType);
         RequestBody requestBody = RequestBody.create(body, mediaType);
         return executeRequest(createRequest(url, "PATCH", headers, mediaType, requestBody));
+    }
+
+    /**
+     * Sends a POST request using HTTP/2 cleartext prior-knowledge (h2c) rather than HTTP/1.1.
+     * <p>
+     * gRPC's wire protocol is HTTP/2-only. OkHttp never attempts HTTP/2 over a plain
+     * {@code "http://"} URL by default — without TLS there is no ALPN negotiation, so a
+     * standard client silently falls back to HTTP/1.1, which a gRPC server cannot understand
+     * at all (the connection is rejected outright). This method routes cleartext targets
+     * through a dedicated client configured for {@link Protocol#H2_PRIOR_KNOWLEDGE} so the
+     * request can actually reach a gRPC service.
+     * <p>
+     * {@code "https://"} targets are unaffected and continue to use the standard client, which
+     * already negotiates HTTP/2 automatically via ALPN when the server supports it.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @param contentType The content type of the request
+     * @param body The request body
+     * @return The full HTTP response
+     * @throws IOException If the request fails (including when the target does not speak h2c)
+     */
+    public HttpResponse postH2c(String url, Map<String, String> headers, String contentType, String body) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType);
+        RequestBody requestBody = RequestBody.create(body, mediaType);
+        Request request = createRequest(url, "POST", headers, mediaType, requestBody);
+
+        OkHttpClient targetClient = url.startsWith("https://") ? client : h2cClient();
+        try (Response response = targetClient.newCall(request).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
+            Map<String, List<String>> responseHeaders = extractHeaders(response);
+            return new HttpResponse(response.code(), responseBody, responseHeaders);
+        }
+    }
+
+    private OkHttpClient h2cClient() {
+        OkHttpClient local = h2cClient;
+        if (local == null) {
+            synchronized (this) {
+                local = h2cClient;
+                if (local == null) {
+                    local = client.newBuilder()
+                            .protocols(List.of(Protocol.H2_PRIOR_KNOWLEDGE))
+                            .build();
+                    h2cClient = local;
+                }
+            }
+        }
+        return local;
     }
 
     /**

--- a/src/main/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCase.java
@@ -100,8 +100,10 @@ public class GrpcEndpointDetectionTestCase implements TestCase {
             try {
                 String url = baseUrl + path;
                 // gRPC frames are binary, but an HTTP POST with the gRPC content-type
-                // lets us detect the service from the response headers alone.
-                HttpResponse response = httpClient.postWithStatus(
+                // lets us detect the service from the response headers alone. gRPC is
+                // HTTP/2-only, so this must go over h2c prior-knowledge for cleartext
+                // targets — a plain HTTP/1.1 request cannot connect to a gRPC server at all.
+                HttpResponse response = httpClient.postH2c(
                         url,
                         Map.of("Content-Type", GRPC_CONTENT_TYPE, "TE", "trailers"),
                         GRPC_CONTENT_TYPE,
@@ -130,7 +132,7 @@ public class GrpcEndpointDetectionTestCase implements TestCase {
 
         try {
             String url = baseUrl + REFLECTION_PATH;
-            HttpResponse response = httpClient.postWithStatus(
+            HttpResponse response = httpClient.postH2c(
                     url,
                     Map.of("Content-Type", GRPC_CONTENT_TYPE, "TE", "trailers"),
                     GRPC_CONTENT_TYPE,

--- a/src/test/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCaseTest.java
@@ -115,7 +115,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointFound() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -131,7 +131,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointNotFound() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(notFound());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -145,7 +145,7 @@ class GrpcEndpointDetectionTestCaseTest {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
         // All probes succeed — but we should only get one finding
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -158,7 +158,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointExceptionHandled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Connection refused"));
 
         assertDoesNotThrow(() -> testCase.detectGrpcEndpoint(endpoint, httpClient),
@@ -172,7 +172,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionEnabled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectServerReflection(endpoint, httpClient);
@@ -190,7 +190,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionNotEnabled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(notFound());
 
         List<Finding> findings = testCase.detectServerReflection(endpoint, httpClient);
@@ -203,7 +203,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionExceptionHandled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Connection refused"));
 
         assertDoesNotThrow(() -> testCase.detectServerReflection(endpoint, httpClient),
@@ -218,7 +218,7 @@ class GrpcEndpointDetectionTestCaseTest {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
         // All probes (detection + reflection) respond with gRPC content-type
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.execute(endpoint, httpClient);
@@ -236,7 +236,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testExecuteExceptionHandledGracefully() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Network error"));
 
         assertDoesNotThrow(() -> testCase.execute(endpoint, httpClient),


### PR DESCRIPTION
Fixes #72

## Summary
`GrpcEndpointDetectionTestCase` probed for gRPC services over the shared `HttpClient`, which wraps a standard OkHttp client. gRPC's wire protocol is HTTP/2-only, and OkHttp never attempts HTTP/2 over a plain `http://` URL by default (there's no ALPN negotiation without TLS) — it silently falls back to HTTP/1.1, which a gRPC server cannot understand at all. The probe request fails at the transport layer before there's ever a response to inspect.

## Reproduction
Built and ran [gRPC Goat](https://github.com/GoSecure/gRPC-Goat) labs 001 (server reflection enabled) and 002 (plaintext gRPC), both confirmed live via `docker logs`. Scanning both produced **0 findings on both**, including lab001 — the "reflection enabled" scenario this test case is specifically meant to catch.

Confirmed the transport-level cause by hand:
```
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8001/
000   # plain HTTP/1.1 — connection never completes

$ curl -s -o /dev/null -w "%{http_code}" --http2-prior-knowledge http://127.0.0.1:8001/
415   # real HTTP/2 connection succeeds — server is genuinely reachable
```

## Fix
Adds `HttpClient.postH2c()`, which routes cleartext (`http://`) targets through a dedicated client configured for `Protocol.H2_PRIOR_KNOWLEDGE`. `https://` targets are unaffected and continue through the standard client, which already negotiates HTTP/2 via ALPN when the server supports it — no change to any other test case's behavior.

## Verification
- Re-ran against both gRPC Goat labs after the fix: **2/2 detection**, up from 0/2. Both now report the gRPC endpoint detection (INFO) and "gRPC Server Reflection Enabled" (MEDIUM).
- Existing unit tests updated to mock `postH2c` instead of `postWithStatus`; all still pass.
- Full suite passes (241 tests).

## Test plan
- [x] `mvn test` passes
- [x] Re-scanned gRPC Goat lab001 and lab002 with the fixed jar — both correctly detected, including reflection