### PR TITLE
fix: discovery no longer mistakes 404 error pages for real endpoints

### DIFF
--- a/src/main/java/org/owasp/astf/core/discovery/EndpointDiscoveryService.java
+++ b/src/main/java/org/owasp/astf/core/discovery/EndpointDiscoveryService.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.owasp.astf.core.EndpointInfo;
 import org.owasp.astf.core.config.ScanConfig;
 import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -137,7 +138,11 @@ public class EndpointDiscoveryService {
             discoveredEndpoints.addAll(resourceEndpoints);
 
             if (discoveredEndpoints.isEmpty()) {
-                logger.warn("No endpoints discovered through automatic methods");
+                logger.warn("No endpoints discovered through automatic methods. This target does not " +
+                        "expose a recognizable OpenAPI/Swagger spec and none of the generic path guesses " +
+                        "resolved to a real endpoint — coverage from the fallback list below will likely " +
+                        "be minimal. For accurate results, supply the target's real routes with " +
+                        "--endpoints-file (one 'METHOD /path' per line) or --config.");
                 // Fallback strategy: Use common endpoints for testing
                 logger.info("Using fallback common endpoints for testing");
                 discoveredEndpoints.addAll(getFallbackEndpoints());
@@ -168,9 +173,13 @@ public class EndpointDiscoveryService {
                 String url = config.getTargetUrl() + specPath;
                 logger.debug("Checking for API specification at: {}", url);
 
-                String response = httpClient.get(url, Map.of());
+                // Must check the status code, not just body non-emptiness: a 404 error page
+                // (which most servers return with a non-empty body) would otherwise be
+                // mistaken for "found something here".
+                HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                if (response != null && !response.isEmpty()) {
+                if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                     logger.info("Found potential API specification at: {}", url);
 
                     // Check if it's a valid JSON response that might be an OpenAPI spec
@@ -332,9 +341,12 @@ public class EndpointDiscoveryService {
                 String url = config.getTargetUrl() + rootPath;
                 logger.debug("Testing API root path: {}", url);
 
-                String response = httpClient.get(url, Map.of());
+                // Gate on the status code, not just a non-empty body: a 404/error page has a
+                // body too, and would otherwise make every generic guess look like a hit.
+                HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                if (response != null && !response.isEmpty()) {
+                if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                     logger.info("Found potential API root at: {}", url);
 
                     // If we get a valid response, add the root path
@@ -385,10 +397,15 @@ public class EndpointDiscoveryService {
                     String url = config.getTargetUrl() + resourcePath;
                     logger.debug("Testing resource path: {}", url);
 
-                    String response = httpClient.get(url, Map.of());
+                    // Gate on the status code rather than sniffing the body for the words
+                    // "error"/"not found"/"404" — those substring checks both miss real 404
+                    // pages that don't happen to say those exact words, and can reject a
+                    // legitimate 200 response whose JSON payload happens to contain them
+                    // (e.g. a field literally named "error").
+                    HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                    String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                    if (response != null && !response.isEmpty() && !response.contains("error") &&
-                            !response.contains("not found") && !response.contains("404")) {
+                    if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                         logger.info("Found potential resource endpoint: {}", url);
 
                         // Add the base resource endpoint

--- a/src/test/java/org/owasp/astf/core/discovery/EndpointDiscoveryServiceTest.java
+++ b/src/test/java/org/owasp/astf/core/discovery/EndpointDiscoveryServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 import org.owasp.astf.core.EndpointInfo;
 import org.owasp.astf.core.config.ScanConfig;
 import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,6 +27,14 @@ class EndpointDiscoveryServiceTest {
 
     private ScanConfig config;
     private EndpointDiscoveryService discoveryService;
+
+    private static HttpResponse ok(String body) {
+        return new HttpResponse(200, body, Map.of());
+    }
+
+    private static HttpResponse notFound() {
+        return new HttpResponse(404, "Not Found", Map.of());
+    }
 
     @BeforeEach
     void setUp() {
@@ -49,7 +58,7 @@ class EndpointDiscoveryServiceTest {
                 """;
 
         // All spec path probes return the swagger JSON
-        when(httpClient.get(anyString(), anyMap())).thenReturn(swagger);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(swagger));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -76,7 +85,7 @@ class EndpointDiscoveryServiceTest {
                 }
                 """;
 
-        when(httpClient.get(anyString(), anyMap())).thenReturn(openApi);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(openApi));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -97,7 +106,7 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should return fallback endpoints when no spec is found and discovery fails")
     void testFallbackEndpointsOnEmptyResponse() throws IOException {
         // All HTTP calls return empty — simulates no spec and no reachable endpoints
-        when(httpClient.get(anyString(), anyMap())).thenReturn("");
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(""));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -109,7 +118,7 @@ class EndpointDiscoveryServiceTest {
     @Test
     @DisplayName("Should return fallback endpoints when HTTP calls throw exceptions")
     void testFallbackEndpointsOnException() throws IOException {
-        when(httpClient.get(anyString(), anyMap())).thenThrow(new IOException("Connection refused"));
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenThrow(new IOException("Connection refused"));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -120,15 +129,15 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should discover endpoints from reachable API roots")
     void testDiscoverFromApiRoot() throws IOException {
         // Spec paths return empty, but the /api root returns a non-empty JSON response
-        when(httpClient.get(anyString(), anyMap())).thenAnswer(inv -> {
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenAnswer(inv -> {
             String url = inv.getArgument(0);
             if (url.contains("swagger") || url.contains("openapi") || url.contains("api-docs")) {
-                return "";
+                return ok("");
             }
             if (url.endsWith("/api")) {
-                return "{\"links\":[]}";
+                return ok("{\"links\":[]}");
             }
-            return "";
+            return ok("");
         });
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
@@ -141,9 +150,28 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should not throw when spec JSON is malformed")
     void testMalformedSpecJson() throws IOException {
         String malformedJson = "{invalid json content}";
-        when(httpClient.get(anyString(), anyMap())).thenReturn(malformedJson);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(malformedJson));
 
         assertDoesNotThrow(() -> discoveryService.discoverEndpoints());
+    }
+
+    @Test
+    @DisplayName("Should not mistake a non-empty 404 error page for a real API root (regression)")
+    void testDoesNotTreat404PageAsDiscoveredEndpoint() throws IOException {
+        // Reproduces the crAPI false-discovery bug: every generic path guess reached a real
+        // web server that replied with a non-empty 404 page (a very common server behavior).
+        // A body-emptiness-only check would misread every single one of these as "found".
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(notFound());
+
+        List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
+
+        // Discovery should fall back to the honest hardcoded fallback list rather than
+        // reporting any of the generic /api, /api/v1, /rest, ... guesses as real endpoints.
+        assertTrue(endpoints.stream().noneMatch(e -> "/api".equals(e.getPath())),
+                "A 404 response for /api should not be reported as a discovered endpoint");
+        assertTrue(endpoints.stream().noneMatch(e -> "/rest".equals(e.getPath())),
+                "A 404 response for /rest should not be reported as a discovered endpoint");
+        assertFalse(endpoints.isEmpty(), "Should still return the fallback endpoint list");
     }
 
     @Test
@@ -161,7 +189,7 @@ class EndpointDiscoveryServiceTest {
                   }
                 }
                 """;
-        when(httpClient.get(anyString(), anyMap())).thenReturn(openApi);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(openApi));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 


### PR DESCRIPTION
Fixes #73

## Summary
`exploreApiRoots()` and `testCommonResourcePatterns()` treated any non-empty HTTP response body as evidence of a real endpoint, without checking the status code. Since most servers return a non-empty body on a 404 (an error page), every generic path guess against a reachable server was misread as "found something here".

## Reproduction
Scanned [OWASP crAPI](https://github.com/OWASP/crAPI) (local docker-compose stack, no self-published OpenAPI spec). Auto-discovery reported:
```
Found potential API root at: http://127.0.0.1:8888//api
Found potential API root at: http://127.0.0.1:8888//api/v1
...
Discovered 8 unique endpoints
```
Every single one was a 404 page from crAPI's nginx gateway for a generic guessed path — none are real crAPI routes (which live under `/identity/api/...`, `/community/api/...`, `/workshop/api/...`). The scan then ran with 0 real coverage while logging as if discovery had succeeded, indistinguishable from "target is secure".

## Fix
Both methods now gate on the response status code (2xx) via `getWithStatus()`, not just body non-emptiness. Also strengthens the "nothing discovered" warning to explicitly name `--endpoints-file`/`--config` as the fix, instead of silently falling back to a generic hardcoded endpoint list with no indication that coverage will be poor.

## Verification
- Re-ran auto-discovery against crAPI after the fix: correctly reports "No endpoints discovered" instead of 8 false hits.
- New regression test reproduces the exact scenario: a target where every generic path guess returns a non-empty 404, asserting none of them are reported as discovered endpoints.
- Full suite passes (241 tests).

## Test plan
- [x] `mvn test` passes
- [x] Re-ran auto-discovery against crAPI with the fixed jar — 0 false endpoints, honest "no endpoints discovered" warning instead