### PR TITLE
fix: scan can no longer hang indefinitely past its configured timeout

### DIFF
--- a/src/main/java/org/owasp/astf/core/Scanner.java
+++ b/src/main/java/org/owasp/astf/core/Scanner.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -107,13 +108,41 @@ public class Scanner {
             // Calculate total tasks for progress tracking
             totalTasks.set(endpoints.size() * testCases.size());
 
-            // Run test cases against endpoints using virtual threads (Java 21)
-            try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            // Run test cases against endpoints using virtual threads (Java 21).
+            //
+            // Deliberately NOT a try-with-resources here: ExecutorService.close() (the
+            // try-with-resources exit path) calls shutdown() — which lets already-running
+            // tasks finish on their own — and then awaits termination in up to 24-hour
+            // increments, repeating until every task terminates. If a single task is stuck
+            // (a bug in a test case, a blocking call that doesn't honor its timeout, ...) that
+            // wait can silently outlast the orTimeout() below by hours, defeating the whole
+            // point of a configured scan timeout: no report would ever get written. The
+            // explicit try/finally below instead force-interrupts remaining tasks and bounds
+            // the wait to a few seconds, guaranteeing scan() always returns with whatever
+            // findings were collected.
+            ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+            // Bounds how many test-case executions (i.e. concurrent outbound HTTP requests)
+            // are in flight at once. Without this, every endpoint x test-case combination
+            // fires as a fully unbounded concurrent virtual thread — e.g. 44 endpoints x 12
+            // test cases = 528 simultaneous requests — which can overwhelm a target (especially
+            // a locally-run, resource-constrained one) badly enough that requests stall well
+            // past any per-request HTTP timeout. --threads/-t (config.getThreads()) is
+            // documented as controlling concurrency but was previously never actually applied.
+            int maxConcurrency = Math.max(1, config.getThreads());
+            Semaphore concurrencyLimiter = new Semaphore(maxConcurrency);
+            try {
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
 
                 for (EndpointInfo endpoint : endpoints) {
                     for (TestCase testCase : testCases) {
                         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                            try {
+                                concurrencyLimiter.acquire();
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                completedTasks.incrementAndGet();
+                                return;
+                            }
                             try {
                                 logger.debug("Executing {} on {}", testCase.getId(), endpoint);
                                 List<Finding> testFindings = testCase.execute(endpoint, httpClient);
@@ -136,6 +165,7 @@ public class Scanner {
                                         testCase.getId(), endpoint.getPath(), e.getMessage());
                                 logger.debug("Exception details:", e);
                             } finally {
+                                concurrencyLimiter.release();
                                 // Update progress
                                 int completed = completedTasks.incrementAndGet();
                                 if (completed % 10 == 0 || completed == totalTasks.get()) {
@@ -156,6 +186,19 @@ public class Scanner {
                             return null;
                         })
                         .join();
+            } finally {
+                // Interrupt anything still running and bound the shutdown wait — see comment
+                // above. A scan must always finish and produce a report, never hang forever.
+                executor.shutdownNow();
+                try {
+                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        logger.warn("{} of {} tasks did not terminate within 10s of shutdown; " +
+                                        "proceeding with the {} finding(s) collected so far.",
+                                totalTasks.get() - completedTasks.get(), totalTasks.get(), findings.size());
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
 
             logger.info("Scan completed. Found {} issues: {} critical, {} high, {} medium, {} low, {} info",

--- a/src/test/java/org/owasp/astf/core/ScannerTest.java
+++ b/src/test/java/org/owasp/astf/core/ScannerTest.java
@@ -14,6 +14,7 @@ import org.owasp.astf.core.result.ScanResult;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -139,6 +140,44 @@ class ScannerTest {
         ScanResult result = new Scanner(config).scan();
 
         assertNotNull(result.getSeveritySummary());
+    }
+
+    @Test
+    @DisplayName("Should not exceed --threads worth of concurrent requests (regression)")
+    void testConcurrencyIsBoundedByThreadsSetting() throws InterruptedException {
+        int maxThreads = 2;
+        AtomicInteger inFlight = new AtomicInteger(0);
+        AtomicInteger maxObservedConcurrency = new AtomicInteger(0);
+
+        // Every request pauses briefly so overlapping requests actually overlap in time,
+        // and records the peak number of requests in flight at once.
+        server.setDispatcher(new Dispatcher() {
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest request) throws InterruptedException {
+                int current = inFlight.incrementAndGet();
+                maxObservedConcurrency.updateAndGet(prev -> Math.max(prev, current));
+                Thread.sleep(150);
+                inFlight.decrementAndGet();
+                return new MockResponse().setResponseCode(401).setBody("{\"error\":\"unauthorized\"}");
+            }
+        });
+
+        ScanConfig config = buildConfig();
+        config.setThreads(maxThreads);
+        // Many endpoints so plenty of tasks are eligible to run concurrently if unbounded.
+        for (int i = 0; i < 10; i++) {
+            config.addEndpoint(new EndpointInfo("/api/resource" + i, "GET"));
+        }
+        config.setEnabledTestCaseIds(List.of("ASTF-API2-2023"));
+
+        new Scanner(config).scan();
+
+        assertTrue(maxObservedConcurrency.get() <= maxThreads,
+                "Peak concurrent requests (" + maxObservedConcurrency.get() +
+                        ") should never exceed the configured thread limit (" + maxThreads + ")");
+        assertTrue(maxObservedConcurrency.get() > 1,
+                "Test should actually exercise concurrency (not just happen to run serially)");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #74

## Summary
Two compounding bugs let a scan hang for hours with no report, no error, and no exit, requiring a manual kill.

**1. Unbounded executor shutdown.** `Scanner.scan()` used try-with-resources on the virtual-thread executor. `ExecutorService.close()` (the try-with-resources exit path) calls `shutdown()` — which lets already-running tasks finish on their own — then awaits termination in up to 24-hour increments, repeating until every task terminates. If a single task never completes, that wait can silently outlast the `orTimeout()` configured via `--timeout` by hours, defeating the entire point of a scan timeout.

**2. `--threads` was cosmetic.** `-t/--threads` (documented as "number of concurrent threads, default 10") was parsed, validated, and printed to the console, but `Scanner.scan()` never read it. Every endpoint × test-case combination fired as a fully unbounded concurrent virtual thread — e.g. 44 endpoints × 12 test cases = 528 simultaneous requests — which can overwhelm a target badly enough that requests stall well past any per-request HTTP timeout.

## Reproduction
Ran against a local OWASP crAPI docker-compose stack with a valid auth token. Progress stalled at 96.6% (510/528 tasks) for hours with zero further log output, well past the default 30-minute `--timeout`. Required a manual process kill; no report was ever produced. Reproduced repeatedly even against a freshly recreated stack (ruling out server-side leftover state as the sole cause), until the concurrency bug (#2) was found and fixed.

## Fix
- Replace the try-with-resources executor with an explicit `try/finally` that calls `shutdownNow()` and bounds the wait to a single 10-second `awaitTermination`, guaranteeing `scan()` always returns with whatever findings were collected — never hangs.
- Add a `Semaphore` sized to `config.getThreads()` around each task's execution, so `--threads` actually bounds concurrent in-flight requests as documented.

## Verification
- After the concurrency fix: the exact crAPI scan that previously hung for hours now completes cleanly — 98 findings, no timeout, no manual kill.
- Before the concurrency fix landed, one intermediate run genuinely hit the 30-minute timeout and confirmed the shutdown-bounding fix works in isolation: it logged the timeout warning, force-shut-down within ~11 seconds, and wrote a report with the findings collected so far, instead of hanging indefinitely.
- New regression test: a mock server that tracks peak concurrent in-flight requests, asserting the peak never exceeds the configured `--threads` value (and that concurrency is actually exercised, not incidentally serial).
- Full suite passes (241 tests).

## Test plan
- [x] `mvn test` passes
- [x] Re-ran the authenticated crAPI scan (the exact original repro) with the fixed jar — completes cleanly with 98 findings, no hang