### PR TITLE
fix: 7 structural bugs in BOPLA, SSRF, BFLA, inventory-mgmt, misconfig, resource-consumption, unsafe-consumption checks

### DIFF
--- a/src/main/java/org/owasp/astf/core/Scanner.java
+++ b/src/main/java/org/owasp/astf/core/Scanner.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -107,13 +108,41 @@ public class Scanner {
             // Calculate total tasks for progress tracking
             totalTasks.set(endpoints.size() * testCases.size());
 
-            // Run test cases against endpoints using virtual threads (Java 21)
-            try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            // Run test cases against endpoints using virtual threads (Java 21).
+            //
+            // Deliberately NOT a try-with-resources here: ExecutorService.close() (the
+            // try-with-resources exit path) calls shutdown() — which lets already-running
+            // tasks finish on their own — and then awaits termination in up to 24-hour
+            // increments, repeating until every task terminates. If a single task is stuck
+            // (a bug in a test case, a blocking call that doesn't honor its timeout, ...) that
+            // wait can silently outlast the orTimeout() below by hours, defeating the whole
+            // point of a configured scan timeout: no report would ever get written. The
+            // explicit try/finally below instead force-interrupts remaining tasks and bounds
+            // the wait to a few seconds, guaranteeing scan() always returns with whatever
+            // findings were collected.
+            ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+            // Bounds how many test-case executions (i.e. concurrent outbound HTTP requests)
+            // are in flight at once. Without this, every endpoint x test-case combination
+            // fires as a fully unbounded concurrent virtual thread — e.g. 44 endpoints x 12
+            // test cases = 528 simultaneous requests — which can overwhelm a target (especially
+            // a locally-run, resource-constrained one) badly enough that requests stall well
+            // past any per-request HTTP timeout. --threads/-t (config.getThreads()) is
+            // documented as controlling concurrency but was previously never actually applied.
+            int maxConcurrency = Math.max(1, config.getThreads());
+            Semaphore concurrencyLimiter = new Semaphore(maxConcurrency);
+            try {
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
 
                 for (EndpointInfo endpoint : endpoints) {
                     for (TestCase testCase : testCases) {
                         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                            try {
+                                concurrencyLimiter.acquire();
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                completedTasks.incrementAndGet();
+                                return;
+                            }
                             try {
                                 logger.debug("Executing {} on {}", testCase.getId(), endpoint);
                                 List<Finding> testFindings = testCase.execute(endpoint, httpClient);
@@ -136,6 +165,7 @@ public class Scanner {
                                         testCase.getId(), endpoint.getPath(), e.getMessage());
                                 logger.debug("Exception details:", e);
                             } finally {
+                                concurrencyLimiter.release();
                                 // Update progress
                                 int completed = completedTasks.incrementAndGet();
                                 if (completed % 10 == 0 || completed == totalTasks.get()) {
@@ -156,6 +186,19 @@ public class Scanner {
                             return null;
                         })
                         .join();
+            } finally {
+                // Interrupt anything still running and bound the shutdown wait — see comment
+                // above. A scan must always finish and produce a report, never hang forever.
+                executor.shutdownNow();
+                try {
+                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        logger.warn("{} of {} tasks did not terminate within 10s of shutdown; " +
+                                        "proceeding with the {} finding(s) collected so far.",
+                                totalTasks.get() - completedTasks.get(), totalTasks.get(), findings.size());
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
 
             logger.info("Scan completed. Found {} issues: {} critical, {} high, {} medium, {} low, {} info",

--- a/src/main/java/org/owasp/astf/core/config/ScanConfig.java
+++ b/src/main/java/org/owasp/astf/core/config/ScanConfig.java
@@ -30,6 +30,12 @@ public class ScanConfig {
     private String apiKeyHeader = "X-API-Key";
     private String bearerToken;
 
+    // A second, distinct authenticated identity (e.g. a separate registered test account),
+    // used only by test cases that need to prove a cross-user authorization bypass (BOLA) —
+    // never merged into the default request headers, since it must never be used as the
+    // scan's primary identity.
+    private String secondaryBearerToken;
+
     // Proxy settings
     private String proxyHost;
     private int proxyPort;
@@ -279,6 +285,26 @@ public class ScanConfig {
                 !headers.containsKey("Authorization")) {
             headers.put("Authorization", "Bearer " + bearerToken);
         }
+    }
+
+    /**
+     * Gets the secondary bearer token — a second, distinct authenticated identity used only for
+     * cross-user authorization testing (e.g. BOLA). Deliberately never merged into the default
+     * request headers.
+     *
+     * @return The secondary bearer token, or {@code null} if not configured
+     */
+    public String getSecondaryBearerToken() {
+        return secondaryBearerToken;
+    }
+
+    /**
+     * Sets the secondary bearer token.
+     *
+     * @param secondaryBearerToken The secondary bearer token
+     */
+    public void setSecondaryBearerToken(String secondaryBearerToken) {
+        this.secondaryBearerToken = secondaryBearerToken;
     }
 
     // Proxy getters/setters

--- a/src/main/java/org/owasp/astf/core/discovery/EndpointDiscoveryService.java
+++ b/src/main/java/org/owasp/astf/core/discovery/EndpointDiscoveryService.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.owasp.astf.core.EndpointInfo;
 import org.owasp.astf.core.config.ScanConfig;
 import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -137,7 +138,11 @@ public class EndpointDiscoveryService {
             discoveredEndpoints.addAll(resourceEndpoints);
 
             if (discoveredEndpoints.isEmpty()) {
-                logger.warn("No endpoints discovered through automatic methods");
+                logger.warn("No endpoints discovered through automatic methods. This target does not " +
+                        "expose a recognizable OpenAPI/Swagger spec and none of the generic path guesses " +
+                        "resolved to a real endpoint — coverage from the fallback list below will likely " +
+                        "be minimal. For accurate results, supply the target's real routes with " +
+                        "--endpoints-file (one 'METHOD /path' per line) or --config.");
                 // Fallback strategy: Use common endpoints for testing
                 logger.info("Using fallback common endpoints for testing");
                 discoveredEndpoints.addAll(getFallbackEndpoints());
@@ -168,9 +173,13 @@ public class EndpointDiscoveryService {
                 String url = config.getTargetUrl() + specPath;
                 logger.debug("Checking for API specification at: {}", url);
 
-                String response = httpClient.get(url, Map.of());
+                // Must check the status code, not just body non-emptiness: a 404 error page
+                // (which most servers return with a non-empty body) would otherwise be
+                // mistaken for "found something here".
+                HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                if (response != null && !response.isEmpty()) {
+                if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                     logger.info("Found potential API specification at: {}", url);
 
                     // Check if it's a valid JSON response that might be an OpenAPI spec
@@ -332,9 +341,12 @@ public class EndpointDiscoveryService {
                 String url = config.getTargetUrl() + rootPath;
                 logger.debug("Testing API root path: {}", url);
 
-                String response = httpClient.get(url, Map.of());
+                // Gate on the status code, not just a non-empty body: a 404/error page has a
+                // body too, and would otherwise make every generic guess look like a hit.
+                HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                if (response != null && !response.isEmpty()) {
+                if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                     logger.info("Found potential API root at: {}", url);
 
                     // If we get a valid response, add the root path
@@ -385,10 +397,15 @@ public class EndpointDiscoveryService {
                     String url = config.getTargetUrl() + resourcePath;
                     logger.debug("Testing resource path: {}", url);
 
-                    String response = httpClient.get(url, Map.of());
+                    // Gate on the status code rather than sniffing the body for the words
+                    // "error"/"not found"/"404" — those substring checks both miss real 404
+                    // pages that don't happen to say those exact words, and can reject a
+                    // legitimate 200 response whose JSON payload happens to contain them
+                    // (e.g. a field literally named "error").
+                    HttpResponse httpResponse = httpClient.getWithStatus(url, Map.of());
+                    String response = httpResponse != null ? httpResponse.getBody() : null;
 
-                    if (response != null && !response.isEmpty() && !response.contains("error") &&
-                            !response.contains("not found") && !response.contains("404")) {
+                    if (httpResponse != null && httpResponse.isSuccess() && response != null && !response.isEmpty()) {
                         logger.info("Found potential resource endpoint: {}", url);
 
                         // Add the base resource endpoint

--- a/src/main/java/org/owasp/astf/core/http/HttpClient.java
+++ b/src/main/java/org/owasp/astf/core/http/HttpClient.java
@@ -24,6 +24,7 @@ import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -50,6 +51,9 @@ public class HttpClient {
     private final ScanConfig config;
     private final Map<String, String> defaultHeaders;
     private final Map<String, List<Cookie>> cookieStore = new HashMap<>();
+
+    // Lazily-built client for HTTP/2 cleartext (h2c) prior-knowledge requests — see postH2c().
+    private volatile OkHttpClient h2cClient;
 
     /**
      * Creates a new HTTP client with the specified configuration.
@@ -152,6 +156,55 @@ public class HttpClient {
         MediaType mediaType = MediaType.parse(contentType);
         RequestBody requestBody = RequestBody.create(body, mediaType);
         return executeRequest(createRequest(url, "PATCH", headers, mediaType, requestBody));
+    }
+
+    /**
+     * Sends a POST request using HTTP/2 cleartext prior-knowledge (h2c) rather than HTTP/1.1.
+     * <p>
+     * gRPC's wire protocol is HTTP/2-only. OkHttp never attempts HTTP/2 over a plain
+     * {@code "http://"} URL by default — without TLS there is no ALPN negotiation, so a
+     * standard client silently falls back to HTTP/1.1, which a gRPC server cannot understand
+     * at all (the connection is rejected outright). This method routes cleartext targets
+     * through a dedicated client configured for {@link Protocol#H2_PRIOR_KNOWLEDGE} so the
+     * request can actually reach a gRPC service.
+     * <p>
+     * {@code "https://"} targets are unaffected and continue to use the standard client, which
+     * already negotiates HTTP/2 automatically via ALPN when the server supports it.
+     *
+     * @param url The target URL
+     * @param headers Additional headers to include
+     * @param contentType The content type of the request
+     * @param body The request body
+     * @return The full HTTP response
+     * @throws IOException If the request fails (including when the target does not speak h2c)
+     */
+    public HttpResponse postH2c(String url, Map<String, String> headers, String contentType, String body) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType);
+        RequestBody requestBody = RequestBody.create(body, mediaType);
+        Request request = createRequest(url, "POST", headers, mediaType, requestBody);
+
+        OkHttpClient targetClient = url.startsWith("https://") ? client : h2cClient();
+        try (Response response = targetClient.newCall(request).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
+            Map<String, List<String>> responseHeaders = extractHeaders(response);
+            return new HttpResponse(response.code(), responseBody, responseHeaders);
+        }
+    }
+
+    private OkHttpClient h2cClient() {
+        OkHttpClient local = h2cClient;
+        if (local == null) {
+            synchronized (this) {
+                local = h2cClient;
+                if (local == null) {
+                    local = client.newBuilder()
+                            .protocols(List.of(Protocol.H2_PRIOR_KNOWLEDGE))
+                            .build();
+                    h2cClient = local;
+                }
+            }
+        }
+        return local;
     }
 
     /**

--- a/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
@@ -50,6 +50,19 @@ public class BrokenAuthenticationTestCase implements TestCase {
             "000000", "123456", "111111", "999999", "654321", "112233"
     );
 
+    // Some APIs return HTTP 200 on both success AND failure, carrying the real result only in
+    // the response body (e.g. VAmPI: {"status":"fail","message":"..."} with a 200 status).
+    // A 2xx status code alone is therefore not sufficient evidence of a successful auth bypass —
+    // it must also be checked against these common failure markers in the body.
+    private static final List<String> AUTH_FAILURE_BODY_MARKERS = List.of(
+            "\"status\":\"fail\"", "\"status\": \"fail\"",
+            "\"success\":false", "\"success\": false",
+            "\"authenticated\":false", "\"authenticated\": false",
+            "incorrect", "invalid credentials", "invalid username", "invalid password",
+            "authentication failed", "login failed", "unauthorized", "access denied",
+            "wrong password", "not correct", "does not match"
+    );
+
     @Override
     public String getId() {
         return "ASTF-API2-2023";
@@ -109,6 +122,24 @@ public class BrokenAuthenticationTestCase implements TestCase {
         return TWO_FA_PATH_PATTERNS.stream().anyMatch(path::contains);
     }
 
+    /**
+     * A 2xx status code alone does not prove an authentication attempt succeeded — some APIs
+     * (e.g. VAmPI) return HTTP 200 for both successful and failed logins, with the real outcome
+     * only in the response body. This checks the status code AND scans the body for common
+     * failure markers before treating the response as a genuine success.
+     */
+    private boolean looksLikeAuthSuccess(HttpResponse response) {
+        if (response == null || !response.isSuccess()) {
+            return false;
+        }
+        String body = response.getBody();
+        if (body == null || body.isBlank()) {
+            return true; // no body to contradict the status code
+        }
+        String lower = body.toLowerCase();
+        return AUTH_FAILURE_BODY_MARKERS.stream().noneMatch(lower::contains);
+    }
+
     private List<Finding> testWeakAuthentication(EndpointInfo endpoint, HttpClient httpClient) {
         List<Finding> findings = new ArrayList<>();
 
@@ -132,7 +163,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                         creds.get("username"), creds.get("password"));
                 HttpResponse response = httpClient.postWithStatus(fullUrl, Map.of(), "application/json", body);
 
-                if (response.isSuccess()) {
+                if (looksLikeAuthSuccess(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "Weak Default Credentials Accepted",
@@ -201,7 +232,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 }
             }
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 // A 2xx response without auth headers indicates missing authentication controls
                 findings.add(buildMissingAuthFinding(endpoint));
             }
@@ -263,7 +294,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 default       -> httpClient.getWithStatus(fullUrl, noneAlgHeaders);
             };
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 Finding finding = new Finding(
                         UUID.randomUUID().toString(),
                         "JWT 'none' Algorithm Accepted",
@@ -373,7 +404,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 default       -> httpClient.getWithStatus(fullUrl, expiredJwtHeaders);
             };
 
-            if (response != null && response.isSuccess()) {
+            if (looksLikeAuthSuccess(response)) {
                 Finding finding = new Finding(
                         UUID.randomUUID().toString(),
                         "Expired JWT Token Accepted",
@@ -490,7 +521,7 @@ public class BrokenAuthenticationTestCase implements TestCase {
                 String body = String.format("{\"code\":\"%s\"}", code);
                 HttpResponse response = httpClient.postWithStatus(fullUrl, Map.of(), "application/json", body);
 
-                if (response != null && response.isSuccess()) {
+                if (looksLikeAuthSuccess(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "2FA/MFA Bypass — Weak OTP Code Accepted",

--- a/src/main/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCase.java
@@ -174,7 +174,8 @@ public class BrokenFunctionLevelAuthorizationTestCase implements TestCase {
 
                 if (getResponse != null && testResponse != null
                         && getResponse.isSuccess()
-                        && testResponse.isSuccess()) {
+                        && testResponse.isSuccess()
+                        && isApiResponse(testResponse)) {
 
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),

--- a/src/main/java/org/owasp/astf/testcases/BrokenObjectPropertyLevelAuthorizationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenObjectPropertyLevelAuthorizationTestCase.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -136,11 +137,14 @@ public class BrokenObjectPropertyLevelAuthorizationTestCase implements TestCase 
                 };
 
                 if (response != null && response.isSuccess()) {
-                    String responseBody = response.getBody().toLowerCase();
+                    String responseBody = response.getBody();
 
-                    // Check if the response reflects the privileged properties we tried to set
-                    boolean privilegeAccepted = payload.keySet().stream()
-                            .anyMatch(key -> responseBody.contains("\"" + key.toLowerCase() + "\""));
+                    // Check the response actually reflects the PRIVILEGED VALUE we submitted, not
+                    // merely the presence of the key. A correctly-defended API commonly echoes back
+                    // the sanitized object (e.g. "isAdmin":false) — checking for the key alone would
+                    // misread that safe behavior as a successful privilege escalation.
+                    boolean privilegeAccepted = payload.entrySet().stream()
+                            .anyMatch(entry -> valueWasReflected(responseBody, entry.getKey(), entry.getValue()));
 
                     if (privilegeAccepted) {
                         Finding finding = new Finding(
@@ -168,6 +172,31 @@ public class BrokenObjectPropertyLevelAuthorizationTestCase implements TestCase 
         }
 
         return findings;
+    }
+
+    /**
+     * Checks whether the response body reflects the specific privileged VALUE submitted for
+     * {@code key} (not merely the key name). A boolean/numeric value must match exactly
+     * (e.g. {@code "isAdmin":true}); a string value must match as a quoted JSON string; a list
+     * value is treated as reflected if any non-empty JSON array follows the key, since matching
+     * the exact array contents isn't worth the complexity for the wildcard-permission case.
+     */
+    private boolean valueWasReflected(String responseBody, String key, Object expectedValue) {
+        if (responseBody == null || responseBody.isEmpty()) {
+            return false;
+        }
+        String valuePattern;
+        if (expectedValue instanceof Boolean || expectedValue instanceof Number) {
+            valuePattern = Pattern.quote(String.valueOf(expectedValue).toLowerCase());
+        } else if (expectedValue instanceof String) {
+            valuePattern = "\"" + Pattern.quote(((String) expectedValue).toLowerCase()) + "\"";
+        } else if (expectedValue instanceof List) {
+            valuePattern = "\\[[^\\]]+\\]";
+        } else {
+            return false;
+        }
+        String keyValuePattern = "\"" + Pattern.quote(key.toLowerCase()) + "\"\\s*:\\s*" + valuePattern;
+        return Pattern.compile(keyValuePattern).matcher(responseBody.toLowerCase()).find();
     }
 
     private String buildJsonPayload(Map<String, Object> payload) {

--- a/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
@@ -65,13 +65,20 @@ public class GraphQLSecurityTestCase implements TestCase {
     private static final String SUGGESTION_PROBE_QUERY =
             "{\"query\":\"{__typenme}\"}";   // intentional typo: __typenme
 
-    // Deeply nested query designed to trigger resource exhaustion
-    private static final String DEEP_QUERY;
+    // Deeply nested query designed to trigger resource exhaustion.
+    //
+    // Built from __Type.ofType — a self-referencing field that is part of the mandatory
+    // introspection schema every spec-compliant GraphQL server exposes — rather than guessed
+    // application field names. A query built from placeholder names like "{a{b{c{...}}}}"
+    // fails schema validation (HTTP 400 "Cannot query field") on any real schema before depth
+    // is ever assessed; chaining ofType always resolves to a real, deeply-nestable field.
+    static final String DEEP_QUERY;
     static {
-        StringBuilder sb = new StringBuilder("{\"query\":\"{ a { b { c { d { e { f { g { h { i { j");
-        for (int i = 0; i < 10; i++) sb.append(" }");
-        sb.append("}}}\"}");
-        DEEP_QUERY = sb.toString();
+        StringBuilder chain = new StringBuilder("kind name");
+        for (int i = 0; i < 12; i++) {
+            chain = new StringBuilder("kind name ofType{" + chain + "}");
+        }
+        DEEP_QUERY = "{\"query\":\"{__schema{types{" + chain + "}}}\"}";
     }
 
     // Batch query — three introspection operations in one HTTP call
@@ -122,6 +129,24 @@ public class GraphQLSecurityTestCase implements TestCase {
     }
 
     // ── Helper: is this endpoint a GraphQL endpoint? ──────────────────────────
+
+    /**
+     * GraphQL servers return HTTP 200 for both successful queries AND validation/execution
+     * errors — per spec, errors are reported in the response body's {@code "errors"} array,
+     * never via HTTP status. A 2xx status therefore does not by itself prove a query was
+     * accepted; the body must also contain real {@code "data"} and be free of an
+     * {@code "errors"} entry (e.g. a depth-limit or schema-validation rejection).
+     */
+    boolean isAcceptedGraphQLQuery(HttpResponse response) {
+        if (response == null || !response.isSuccess()) {
+            return false;
+        }
+        String body = response.getBody();
+        if (body == null || body.isBlank() || !body.contains("\"data\"")) {
+            return false;
+        }
+        return !body.contains("\"errors\"");
+    }
 
     boolean isGraphQLEndpoint(EndpointInfo endpoint) {
         String path = endpoint.getPath().toLowerCase();
@@ -175,9 +200,13 @@ public class GraphQLSecurityTestCase implements TestCase {
             HttpResponse response = httpClient.postWithStatus(
                     endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, INTROSPECTION_QUERY);
 
-            if (response != null && response.isSuccess()) {
+            if (isAcceptedGraphQLQuery(response)) {
                 String body = response.getBody();
-                if (body != null && body.contains("__schema")) {
+                // "queryType" only appears in a genuine introspection result (it's a field we
+                // explicitly requested) — unlike a bare "__schema" substring check, it can't be
+                // accidentally matched by an error message such as
+                // `"Cannot query field \"__schema\" on type \"Query\"."` when introspection is disabled.
+                if (body != null && body.contains("queryType")) {
                     Finding f = new Finding(
                             UUID.randomUUID().toString(),
                             "GraphQL Introspection Enabled in Production",
@@ -254,8 +283,9 @@ public class GraphQLSecurityTestCase implements TestCase {
             HttpResponse response = httpClient.postWithStatus(
                     endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, DEEP_QUERY);
 
-            if (response != null && response.isSuccess()) {
-                // The server accepted the deeply nested query without rejecting it
+            if (isAcceptedGraphQLQuery(response)) {
+                // The server resolved the deeply nested query (real "data", no "errors") instead
+                // of rejecting it — depth limiting is not enforced.
                 Finding f = new Finding(
                         UUID.randomUUID().toString(),
                         "GraphQL Query Depth Limit Not Enforced",
@@ -270,7 +300,7 @@ public class GraphQLSecurityTestCase implements TestCase {
                         "Recommended maximum depth: 5-10 levels."
                 );
                 f.setEvidence("Server returned HTTP " + response.getStatusCode() +
-                        " for a query nested 10+ levels deep");
+                        " with resolved data (no errors) for a query nested 12+ levels deep via __Type.ofType");
                 findings.add(f);
             }
         } catch (Exception e) {

--- a/src/main/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCase.java
@@ -100,8 +100,10 @@ public class GrpcEndpointDetectionTestCase implements TestCase {
             try {
                 String url = baseUrl + path;
                 // gRPC frames are binary, but an HTTP POST with the gRPC content-type
-                // lets us detect the service from the response headers alone.
-                HttpResponse response = httpClient.postWithStatus(
+                // lets us detect the service from the response headers alone. gRPC is
+                // HTTP/2-only, so this must go over h2c prior-knowledge for cleartext
+                // targets — a plain HTTP/1.1 request cannot connect to a gRPC server at all.
+                HttpResponse response = httpClient.postH2c(
                         url,
                         Map.of("Content-Type", GRPC_CONTENT_TYPE, "TE", "trailers"),
                         GRPC_CONTENT_TYPE,
@@ -130,7 +132,7 @@ public class GrpcEndpointDetectionTestCase implements TestCase {
 
         try {
             String url = baseUrl + REFLECTION_PATH;
-            HttpResponse response = httpClient.postWithStatus(
+            HttpResponse response = httpClient.postH2c(
                     url,
                     Map.of("Content-Type", GRPC_CONTENT_TYPE, "TE", "trailers"),
                     GRPC_CONTENT_TYPE,

--- a/src/main/java/org/owasp/astf/testcases/ImproperInventoryManagementTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/ImproperInventoryManagementTestCase.java
@@ -101,7 +101,7 @@ public class ImproperInventoryManagementTestCase implements TestCase {
             try {
                 HttpResponse response = httpClient.getWithStatus(oldUrl, Map.of());
 
-                if (response != null && response.isSuccess()) {
+                if (response != null && response.isSuccess() && isApiResponse(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "Deprecated API Version Still Accessible",
@@ -133,7 +133,7 @@ public class ImproperInventoryManagementTestCase implements TestCase {
             String shadowUrl = cleanBase + shadowPath;
             try {
                 HttpResponse response = httpClient.getWithStatus(shadowUrl, Map.of());
-                if (response != null && response.isSuccess()) {
+                if (response != null && response.isSuccess() && isApiResponse(response)) {
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "Shadow/Non-Production API Endpoint Accessible",
@@ -168,12 +168,21 @@ public class ImproperInventoryManagementTestCase implements TestCase {
 
         String cleanBase = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
 
+        // Several of the probed paths (e.g. /docs, /redoc, /swagger-ui.html) are legitimately
+        // HTML by design, so a content-type guard would wrongly reject real documentation pages.
+        // Instead, fetch a deliberately-nonexistent path first: a SPA/reverse-proxy catch-all
+        // that returns the same generic fallback page for every unknown path will return
+        // identical content here and for every doc path probed below — that shared fallback
+        // body is not evidence of real documentation being exposed.
+        String fallbackBody = fetchFallbackBaseline(cleanBase, httpClient);
+
         for (String docPath : EXPOSED_DOC_ENDPOINTS) {
             String testUrl = cleanBase + docPath;
             try {
                 HttpResponse response = httpClient.getWithStatus(testUrl, Map.of());
 
-                if (response != null && response.isSuccess() && !response.getBody().isEmpty()) {
+                if (response != null && response.isSuccess() && !response.getBody().isEmpty()
+                        && !response.getBody().equals(fallbackBody)) {
                     boolean isApiSpec = response.getBody().contains("\"openapi\"")
                             || response.getBody().contains("\"swagger\"")
                             || response.getBody().contains("swagger:")
@@ -207,5 +216,55 @@ public class ImproperInventoryManagementTestCase implements TestCase {
         }
 
         return findings;
+    }
+
+    /**
+     * Fetches a deliberately-nonexistent path so its response body can be used as a baseline for
+     * "this is just the generic SPA/reverse-proxy fallback page", per the comment in
+     * {@link #testExposedDocumentation}. Returns {@code null} on any failure, in which case no
+     * doc-path response will match it and the check behaves as it did before this fix.
+     */
+    private String fetchFallbackBaseline(String cleanBase, HttpClient httpClient) {
+        try {
+            HttpResponse response = httpClient.getWithStatus(
+                    cleanBase + "/__astf_nonexistent_path_check__", Map.of());
+            return response != null ? response.getBody() : null;
+        } catch (Exception e) {
+            logger.debug("Error fetching fallback baseline for {}: {}", cleanBase, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Returns true when a response looks like a real API/service response rather than an HTML
+     * page. SPAs and reverse proxies typically return HTTP 200 with text/html for every unknown
+     * path (client-side routing fallback), which would otherwise produce false positives for
+     * deprecated-version and shadow-endpoint probing (documentation endpoints are handled
+     * separately in {@link #testExposedDocumentation}, since some of them are legitimately HTML).
+     */
+    private boolean isApiResponse(HttpResponse response) {
+        String contentType = response.getHeaders().entrySet().stream()
+                .filter(e -> e.getKey() != null && e.getKey().equalsIgnoreCase("Content-Type"))
+                .flatMap(e -> e.getValue().stream())
+                .findFirst()
+                .orElse("")
+                .toLowerCase();
+
+        if (!contentType.isEmpty()) {
+            if (contentType.contains("text/html")) {
+                return false;
+            }
+            if (contentType.contains("json") || contentType.contains("xml") || contentType.contains("text/plain")) {
+                return true;
+            }
+        }
+
+        String body = response.getBody();
+        if (body != null) {
+            String trimmed = body.stripLeading();
+            return trimmed.startsWith("{") || trimmed.startsWith("[");
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/owasp/astf/testcases/SecurityMisconfigurationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/SecurityMisconfigurationTestCase.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,6 +35,14 @@ public class SecurityMisconfigurationTestCase implements TestCase {
             "X-XSS-Protection"
     );
 
+    // Endpoints that are conventionally, intentionally public (e.g. container orchestration
+    // liveness/readiness probes) — exposure alone isn't a meaningful misconfiguration, so these
+    // get a lower severity than genuine debug/dump endpoints unless they leak real content.
+    private static final List<String> CONVENTIONALLY_PUBLIC_ENDPOINTS = List.of(
+            "/info", "/health", "/status", "/ping",
+            "/actuator/health", "/actuator/info"
+    );
+
     private static final List<String> DEBUG_ENDPOINTS = List.of(
             "/actuator", "/actuator/health", "/actuator/env", "/actuator/beans",
             "/actuator/mappings", "/actuator/metrics", "/actuator/info",
@@ -46,12 +55,19 @@ public class SecurityMisconfigurationTestCase implements TestCase {
             "/trace", "/dump", "/heapdump", "/threaddump"
     );
 
+    // Sensitive-value patterns require a colon/quote after the keyword, so a generic message
+    // like "invalid API key" (no actual value disclosed) doesn't match — only an actual
+    // key-value-shaped disclosure like "password": "..." or apiKey=... does.
+    private static final List<String> ERROR_SENSITIVE_VALUE_PATTERNS = List.of(
+            "password[\"']?\\s*[:=]", "secret[\"']?\\s*[:=]", "api[_-]?key[\"']?\\s*[:=]",
+            "credential[\"']?\\s*[:=]", "private[_-]?key[\"']?\\s*[:=]"
+    );
+
     private static final List<String> ERROR_SENSITIVE_PATTERNS = List.of(
             "stack trace", "stacktrace", "at org.", "at java.", "at com.",
             "exception", "NullPointerException", "SQLException",
             "org.springframework", "hibernate", "datasource",
-            "internal server error at", "caused by:",
-            "password", "secret", "token", "key", "credential"
+            "internal server error at", "caused by:"
     );
 
     @Override
@@ -192,19 +208,28 @@ public class SecurityMisconfigurationTestCase implements TestCase {
 
                 if (response != null && response.isSuccess()
                         && !response.getBody().isEmpty()) {
+                    boolean conventionallyPublic = CONVENTIONALLY_PUBLIC_ENDPOINTS.contains(debugPath);
                     Finding finding = new Finding(
                             UUID.randomUUID().toString(),
                             "Debug/Diagnostic Endpoint Exposed",
                             String.format("The debug or diagnostic endpoint '%s' is publicly accessible " +
-                                    "and returned a non-empty response. Debug endpoints can expose sensitive " +
-                                    "configuration, environment variables, internal routes, and system internals.",
-                                    debugPath),
-                            Severity.HIGH,
+                                    "and returned a non-empty response.%s",
+                                    debugPath,
+                                    conventionallyPublic
+                                            ? " This path is conventionally public (e.g. container " +
+                                              "orchestration health checks) — verify it doesn't leak " +
+                                              "internal details beyond a basic status."
+                                            : " Debug endpoints can expose sensitive configuration, " +
+                                              "environment variables, internal routes, and system internals."),
+                            conventionallyPublic ? Severity.LOW : Severity.HIGH,
                             getId(),
                             "GET " + debugPath,
-                            "Disable or restrict access to debug endpoints in production environments. " +
-                            "If these endpoints are required, protect them with authentication and restrict " +
-                            "access to internal networks or VPN only."
+                            conventionallyPublic
+                                    ? "Confirm this endpoint returns only a minimal status payload with no " +
+                                      "environment, configuration, or internal implementation details."
+                                    : "Disable or restrict access to debug endpoints in production environments. " +
+                                      "If these endpoints are required, protect them with authentication and " +
+                                      "restrict access to internal networks or VPN only."
                     );
                     finding.setRequestDetails("GET " + testUrl);
                     finding.setResponseDetails("HTTP " + response.getStatusCode() +
@@ -243,6 +268,14 @@ public class SecurityMisconfigurationTestCase implements TestCase {
                     for (String pattern : ERROR_SENSITIVE_PATTERNS) {
                         if (body.contains(pattern.toLowerCase())) {
                             foundPatterns.add(pattern);
+                        }
+                    }
+                    // Value-shaped patterns require the keyword to be followed by ":" or "=" —
+                    // a generic message like "invalid API key" doesn't match, but an actual
+                    // disclosed value like "password": "hunter2" or apiKey=abc123 does.
+                    for (String valuePattern : ERROR_SENSITIVE_VALUE_PATTERNS) {
+                        if (Pattern.compile(valuePattern).matcher(body).find()) {
+                            foundPatterns.add(valuePattern.replaceAll("[\\[\\]\"'?:=\\\\+-]", "").trim());
                         }
                     }
 

--- a/src/main/java/org/owasp/astf/testcases/ServerSideRequestForgeryTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/ServerSideRequestForgeryTestCase.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -89,6 +91,7 @@ public class ServerSideRequestForgeryTestCase implements TestCase {
         }
 
         String baseUrl = endpoint.getFullUrl();
+        Set<String> baselineIndicators = fetchBaselineIndicators(endpoint, httpClient);
 
         for (String param : URL_PARAMETERS) {
             for (String payload : SSRF_PAYLOADS) {
@@ -97,7 +100,7 @@ public class ServerSideRequestForgeryTestCase implements TestCase {
                 try {
                     HttpResponse response = httpClient.getWithStatus(testUrl, Map.of());
 
-                    if (response != null && containsSsrfIndicator(response.getBody())) {
+                    if (response != null && containsNewSsrfIndicator(response.getBody(), baselineIndicators)) {
                         Finding finding = new Finding(
                                 UUID.randomUUID().toString(),
                                 "Server Side Request Forgery (SSRF) via Query Parameter",
@@ -134,6 +137,8 @@ public class ServerSideRequestForgeryTestCase implements TestCase {
             return findings;
         }
 
+        Set<String> baselineIndicators = fetchBaselineIndicators(endpoint, httpClient);
+
         for (String param : URL_PARAMETERS) {
             for (String payload : SSRF_PAYLOADS) {
                 String body = String.format("{\"%s\":\"%s\"}", param, payload);
@@ -145,7 +150,7 @@ public class ServerSideRequestForgeryTestCase implements TestCase {
                         default      -> null;
                     };
 
-                    if (response != null && containsSsrfIndicator(response.getBody())) {
+                    if (response != null && containsNewSsrfIndicator(response.getBody(), baselineIndicators)) {
                         Finding finding = new Finding(
                                 UUID.randomUUID().toString(),
                                 "Server Side Request Forgery (SSRF) via Request Body",
@@ -173,10 +178,40 @@ public class ServerSideRequestForgeryTestCase implements TestCase {
         return findings;
     }
 
-    private boolean containsSsrfIndicator(String body) {
+    /**
+     * Fetches the endpoint's normal (un-injected) response and returns the set of SSRF
+     * indicators that already appear in it. Some indicators (notably the generic environment
+     * words "docker"/"kubernetes"/"k8s") can legitimately appear in an API's ordinary response —
+     * without this baseline, every probe against such an endpoint would be a false positive.
+     */
+    private Set<String> fetchBaselineIndicators(EndpointInfo endpoint, HttpClient httpClient) {
+        try {
+            HttpResponse baseline = httpClient.getWithStatus(endpoint.getFullUrl(), Map.of());
+            if (baseline == null || baseline.getBody() == null) {
+                return Set.of();
+            }
+            String lower = baseline.getBody().toLowerCase();
+            return SSRF_INDICATORS.stream()
+                    .filter(indicator -> lower.contains(indicator.toLowerCase()))
+                    .collect(Collectors.toUnmodifiableSet());
+        } catch (Exception e) {
+            logger.debug("Error fetching SSRF baseline for {}: {}", endpoint, e.getMessage());
+            return Set.of();
+        }
+    }
+
+    /**
+     * Returns true only when the response contains an SSRF indicator that was NOT already
+     * present in the endpoint's baseline (un-injected) response — i.e. the indicator's
+     * appearance is actually attributable to the injected payload, not just how this API
+     * normally talks.
+     */
+    private boolean containsNewSsrfIndicator(String body, Set<String> baselineIndicators) {
         if (body == null || body.isEmpty()) return false;
         String lower = body.toLowerCase();
-        return SSRF_INDICATORS.stream().anyMatch(indicator -> lower.contains(indicator.toLowerCase()));
+        return SSRF_INDICATORS.stream()
+                .filter(indicator -> !baselineIndicators.contains(indicator))
+                .anyMatch(indicator -> lower.contains(indicator.toLowerCase()));
     }
 
     private String urlEncode(String value) {

--- a/src/main/java/org/owasp/astf/testcases/UnrestrictedResourceConsumptionTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/UnrestrictedResourceConsumptionTestCase.java
@@ -29,6 +29,14 @@ public class UnrestrictedResourceConsumptionTestCase implements TestCase {
     private static final int RATE_LIMIT_TEST_REQUESTS = 20;
     private static final int RATE_LIMIT_THRESHOLD = 15; // 15+ successes = likely no rate limiting
 
+    // A 2xx status alone doesn't prove the request was genuinely accepted — some APIs return
+    // 200 with an explicit rate-limit/quota rejection message in the body instead of a 429/4xx
+    // status. These phrases are specific enough that they're unlikely to appear in an unrelated
+    // healthy response.
+    private static final List<String> FAILURE_BODY_MARKERS = List.of(
+            "quota exceeded", "rate limit exceeded", "too many requests", "throttled", "slow down"
+    );
+
     @Override
     public String getId() {
         return "ASTF-API4-2023";
@@ -80,7 +88,7 @@ public class UnrestrictedResourceConsumptionTestCase implements TestCase {
             try {
                 HttpResponse response = httpClient.getWithStatus(fullUrl, Map.of());
                 if (response != null) {
-                    if (response.isRateLimited()) {
+                    if (response.isRateLimited() || bodyIndicatesRateLimited(response.getBody())) {
                         rateLimitedCount++;
                         break; // Rate limiting is working
                     } else if (response.isSuccess()) {
@@ -116,6 +124,22 @@ public class UnrestrictedResourceConsumptionTestCase implements TestCase {
         return findings;
     }
 
+    private boolean looksLikeJsonData(String body) {
+        if (body == null) {
+            return false;
+        }
+        String trimmed = body.stripLeading();
+        return trimmed.startsWith("{") || trimmed.startsWith("[");
+    }
+
+    private boolean bodyIndicatesRateLimited(String body) {
+        if (body == null || body.isEmpty()) {
+            return false;
+        }
+        String lower = body.toLowerCase();
+        return FAILURE_BODY_MARKERS.stream().anyMatch(lower::contains);
+    }
+
     private List<Finding> testLargePaginationRequests(EndpointInfo endpoint, HttpClient httpClient) {
         List<Finding> findings = new ArrayList<>();
 
@@ -138,8 +162,11 @@ public class UnrestrictedResourceConsumptionTestCase implements TestCase {
                 HttpResponse response = httpClient.getWithStatus(testUrl, Map.of());
                 if (response != null && response.isSuccess()) {
                     String body = response.getBody();
-                    // A response body larger than 1MB suggests unbounded data return
-                    if (body.length() > 1_000_000) {
+                    // A response body larger than 1MB suggests unbounded data return — but only
+                    // when it's actually JSON/array data. A large non-JSON body (e.g. a default
+                    // server error page, or an HTML page for an unrecognized query param) is not
+                    // evidence of a missing pagination limit.
+                    if (body.length() > 1_000_000 && looksLikeJsonData(body)) {
                         Finding finding = new Finding(
                                 UUID.randomUUID().toString(),
                                 "Missing Pagination Limit - Large Response Returned",
@@ -194,8 +221,9 @@ public class UnrestrictedResourceConsumptionTestCase implements TestCase {
                     || body.contains("\"next\"") || body.contains("\"pagination\"")
                     || body.contains("\"cursor\"");
 
-            // If large response with no pagination indicators, flag it
-            if (body.length() > 100_000 && !hasPaginationHeaders && !hasPaginationInBody) {
+            // If large response with no pagination indicators, flag it — again, only when the
+            // body is actually JSON data, to avoid miscounting a large non-API HTML page.
+            if (body.length() > 100_000 && looksLikeJsonData(body) && !hasPaginationHeaders && !hasPaginationInBody) {
                 Finding finding = new Finding(
                         UUID.randomUUID().toString(),
                         "Missing Pagination on Collection Endpoint",

--- a/src/main/java/org/owasp/astf/testcases/UnsafeConsumptionOfApisTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/UnsafeConsumptionOfApisTestCase.java
@@ -46,14 +46,21 @@ public class UnsafeConsumptionOfApisTestCase implements TestCase {
             "\r\nX-Injected-Header: value" // HTTP header injection
     );
 
-    // Patterns that indicate successful injection in responses
+    // Patterns that indicate successful injection in a 2xx response
     private static final List<String> INJECTION_SUCCESS_PATTERNS = List.of(
             "<script>",               // Unescaped XSS
             "alert('xss')",           // XSS executed context
             "49",                     // 7*7=49 template injection
             "root:x:0:0",            // /etc/passwd content
-            "X-Injected-Header",     // Header injection reflected
-            "sql", "syntax error", "mysql", "sqlite", "postgresql" // SQL errors
+            "X-Injected-Header"      // Header injection reflected
+    );
+
+    // SQL-error patterns are checked separately against error (5xx) responses — real
+    // error-based SQL injection almost always manifests as a 500 with the DB error text,
+    // not a 2xx, so gating these behind isSuccess() would make the most common signal
+    // unreachable.
+    private static final List<String> SQL_ERROR_PATTERNS = List.of(
+            "sql syntax", "syntax error", "mysql", "sqlite", "postgresql", "ora-0", "sqlstate"
     );
 
     @Override
@@ -136,6 +143,32 @@ public class UnsafeConsumptionOfApisTestCase implements TestCase {
                             finding.setEvidence("Payload: " + payload + "\nPattern found: " + pattern);
                             findings.add(finding);
                             return findings; // One injection finding is enough
+                        }
+                    }
+                } else if (response != null && response.isServerError()) {
+                    // Error-based SQL injection almost always surfaces as a 5xx with the raw
+                    // database error text, not a 2xx — check separately from the success path.
+                    String responseBody = response.getBody().toLowerCase();
+                    for (String pattern : SQL_ERROR_PATTERNS) {
+                        if (responseBody.contains(pattern)) {
+                            Finding finding = new Finding(
+                                    UUID.randomUUID().toString(),
+                                    "SQL Injection in API Integration Endpoint",
+                                    String.format("The API integration endpoint at '%s' returned a database " +
+                                            "error containing '%s' after receiving an injection payload, " +
+                                            "indicating the input was passed unsanitized into a database query.",
+                                            endpoint.getPath(), pattern),
+                                    Severity.CRITICAL,
+                                    getId(),
+                                    endpoint.getMethod() + " " + endpoint.getPath(),
+                                    "Use parameterized queries or prepared statements for all database " +
+                                    "operations. Never concatenate untrusted input into SQL strings. " +
+                                    "Return generic error messages to clients; log details server-side only."
+                            );
+                            finding.setEvidence("Payload: " + payload + "\nHTTP " + response.getStatusCode() +
+                                    " with pattern found: " + pattern);
+                            findings.add(finding);
+                            return findings;
                         }
                     }
                 }

--- a/src/test/java/org/owasp/astf/core/ScannerTest.java
+++ b/src/test/java/org/owasp/astf/core/ScannerTest.java
@@ -14,6 +14,7 @@ import org.owasp.astf.core.result.ScanResult;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -139,6 +140,44 @@ class ScannerTest {
         ScanResult result = new Scanner(config).scan();
 
         assertNotNull(result.getSeveritySummary());
+    }
+
+    @Test
+    @DisplayName("Should not exceed --threads worth of concurrent requests (regression)")
+    void testConcurrencyIsBoundedByThreadsSetting() throws InterruptedException {
+        int maxThreads = 2;
+        AtomicInteger inFlight = new AtomicInteger(0);
+        AtomicInteger maxObservedConcurrency = new AtomicInteger(0);
+
+        // Every request pauses briefly so overlapping requests actually overlap in time,
+        // and records the peak number of requests in flight at once.
+        server.setDispatcher(new Dispatcher() {
+            @NotNull
+            @Override
+            public MockResponse dispatch(@NotNull RecordedRequest request) throws InterruptedException {
+                int current = inFlight.incrementAndGet();
+                maxObservedConcurrency.updateAndGet(prev -> Math.max(prev, current));
+                Thread.sleep(150);
+                inFlight.decrementAndGet();
+                return new MockResponse().setResponseCode(401).setBody("{\"error\":\"unauthorized\"}");
+            }
+        });
+
+        ScanConfig config = buildConfig();
+        config.setThreads(maxThreads);
+        // Many endpoints so plenty of tasks are eligible to run concurrently if unbounded.
+        for (int i = 0; i < 10; i++) {
+            config.addEndpoint(new EndpointInfo("/api/resource" + i, "GET"));
+        }
+        config.setEnabledTestCaseIds(List.of("ASTF-API2-2023"));
+
+        new Scanner(config).scan();
+
+        assertTrue(maxObservedConcurrency.get() <= maxThreads,
+                "Peak concurrent requests (" + maxObservedConcurrency.get() +
+                        ") should never exceed the configured thread limit (" + maxThreads + ")");
+        assertTrue(maxObservedConcurrency.get() > 1,
+                "Test should actually exercise concurrency (not just happen to run serially)");
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/org/owasp/astf/core/discovery/EndpointDiscoveryServiceTest.java
+++ b/src/test/java/org/owasp/astf/core/discovery/EndpointDiscoveryServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.MockitoAnnotations;
 import org.owasp.astf.core.EndpointInfo;
 import org.owasp.astf.core.config.ScanConfig;
 import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,6 +27,14 @@ class EndpointDiscoveryServiceTest {
 
     private ScanConfig config;
     private EndpointDiscoveryService discoveryService;
+
+    private static HttpResponse ok(String body) {
+        return new HttpResponse(200, body, Map.of());
+    }
+
+    private static HttpResponse notFound() {
+        return new HttpResponse(404, "Not Found", Map.of());
+    }
 
     @BeforeEach
     void setUp() {
@@ -49,7 +58,7 @@ class EndpointDiscoveryServiceTest {
                 """;
 
         // All spec path probes return the swagger JSON
-        when(httpClient.get(anyString(), anyMap())).thenReturn(swagger);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(swagger));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -76,7 +85,7 @@ class EndpointDiscoveryServiceTest {
                 }
                 """;
 
-        when(httpClient.get(anyString(), anyMap())).thenReturn(openApi);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(openApi));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -97,7 +106,7 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should return fallback endpoints when no spec is found and discovery fails")
     void testFallbackEndpointsOnEmptyResponse() throws IOException {
         // All HTTP calls return empty — simulates no spec and no reachable endpoints
-        when(httpClient.get(anyString(), anyMap())).thenReturn("");
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(""));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -109,7 +118,7 @@ class EndpointDiscoveryServiceTest {
     @Test
     @DisplayName("Should return fallback endpoints when HTTP calls throw exceptions")
     void testFallbackEndpointsOnException() throws IOException {
-        when(httpClient.get(anyString(), anyMap())).thenThrow(new IOException("Connection refused"));
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenThrow(new IOException("Connection refused"));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 
@@ -120,15 +129,15 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should discover endpoints from reachable API roots")
     void testDiscoverFromApiRoot() throws IOException {
         // Spec paths return empty, but the /api root returns a non-empty JSON response
-        when(httpClient.get(anyString(), anyMap())).thenAnswer(inv -> {
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenAnswer(inv -> {
             String url = inv.getArgument(0);
             if (url.contains("swagger") || url.contains("openapi") || url.contains("api-docs")) {
-                return "";
+                return ok("");
             }
             if (url.endsWith("/api")) {
-                return "{\"links\":[]}";
+                return ok("{\"links\":[]}");
             }
-            return "";
+            return ok("");
         });
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
@@ -141,9 +150,28 @@ class EndpointDiscoveryServiceTest {
     @DisplayName("Should not throw when spec JSON is malformed")
     void testMalformedSpecJson() throws IOException {
         String malformedJson = "{invalid json content}";
-        when(httpClient.get(anyString(), anyMap())).thenReturn(malformedJson);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(malformedJson));
 
         assertDoesNotThrow(() -> discoveryService.discoverEndpoints());
+    }
+
+    @Test
+    @DisplayName("Should not mistake a non-empty 404 error page for a real API root (regression)")
+    void testDoesNotTreat404PageAsDiscoveredEndpoint() throws IOException {
+        // Reproduces the crAPI false-discovery bug: every generic path guess reached a real
+        // web server that replied with a non-empty 404 page (a very common server behavior).
+        // A body-emptiness-only check would misread every single one of these as "found".
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(notFound());
+
+        List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
+
+        // Discovery should fall back to the honest hardcoded fallback list rather than
+        // reporting any of the generic /api, /api/v1, /rest, ... guesses as real endpoints.
+        assertTrue(endpoints.stream().noneMatch(e -> "/api".equals(e.getPath())),
+                "A 404 response for /api should not be reported as a discovered endpoint");
+        assertTrue(endpoints.stream().noneMatch(e -> "/rest".equals(e.getPath())),
+                "A 404 response for /rest should not be reported as a discovered endpoint");
+        assertFalse(endpoints.isEmpty(), "Should still return the fallback endpoint list");
     }
 
     @Test
@@ -161,7 +189,7 @@ class EndpointDiscoveryServiceTest {
                   }
                 }
                 """;
-        when(httpClient.get(anyString(), anyMap())).thenReturn(openApi);
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(ok(openApi));
 
         List<EndpointInfo> endpoints = discoveryService.discoverEndpoints();
 

--- a/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
@@ -254,6 +254,37 @@ class BrokenAuthenticationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should NOT flag weak credentials when HTTP 200 body indicates the login actually failed (VAmPI-style false positive)")
+    void testWeakCredentialsNoFalsePositiveOn200WithFailureBody() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/login", "POST", "application/json", "{}", true);
+
+        // Mirrors VAmPI: login always returns HTTP 200, real result is in the body.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"status\": \"fail\", \"message\": \"Username or Password Incorrect!\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> "Weak Default Credentials Accepted".equals(f.getTitle())),
+                "Should not report weak credentials accepted when the response body says the login failed");
+        assertTrue(findings.stream().noneMatch(f -> "2FA/MFA Bypass — Weak OTP Code Accepted".equals(f.getTitle())),
+                "Should not report OTP bypass when the response body says the attempt failed");
+    }
+
+    @Test
+    @DisplayName("Should still flag weak credentials when HTTP 200 body has no failure indicator")
+    void testWeakCredentialsStillDetectedOnGenuineSuccess() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/login", "POST", "application/json", "{}", true);
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"auth_token\": \"abc123\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> "Weak Default Credentials Accepted".equals(f.getTitle())),
+                "Should still report weak credentials accepted on a genuine 200 success with no failure markers");
+    }
+
+    @Test
     @DisplayName("Should detect sensitive tokens exposed in URL query parameters")
     void testTokenInUrl() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/data?token=abc123secret", "GET", "application/json", null, false);

--- a/src/test/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCaseTest.java
@@ -94,6 +94,28 @@ class BrokenFunctionLevelAuthorizationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should NOT flag method escalation when responses are an SPA/reverse-proxy HTML fallback (regression)")
+    void testNoMethodEscalationOnHtmlFallback() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        // A single-page app / catch-all reverse proxy returns 200 text/html for every method,
+        // including PUT/DELETE/PATCH — this must not be read as "method escalation allowed".
+        HttpResponse htmlFallback = new HttpResponse(200, "<html><body>App</body></html>",
+                Map.of("Content-Type", List.of("text/html")));
+
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenReturn(htmlFallback);
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(), anyString())).thenReturn(htmlFallback);
+        when(httpClient.deleteWithStatus(anyString(), anyMap())).thenReturn(htmlFallback);
+        when(httpClient.patchWithStatus(anyString(), anyMap(), anyString(), anyString())).thenReturn(htmlFallback);
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Method")),
+                "Should not flag HTTP method escalation when the response is an HTML SPA fallback page");
+    }
+
+    @Test
     @DisplayName("Should return empty when admin endpoints return 401/403")
     void testAdminEndpointReturns401() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");

--- a/src/test/java/org/owasp/astf/testcases/BrokenObjectPropertyLevelAuthorizationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenObjectPropertyLevelAuthorizationTestCaseTest.java
@@ -169,6 +169,26 @@ class BrokenObjectPropertyLevelAuthorizationTestCaseTest {
     }
 
     /**
+     * A server that sanitizes the field and echoes back the safe value (e.g. "isAdmin":false)
+     * should NOT be flagged — the key being present is not evidence of privilege escalation,
+     * only the privileged VALUE being reflected is.
+     */
+    @Test
+    @DisplayName("No mass-assignment finding when the key is present but sanitized to a safe value")
+    void noMassAssignmentWhenValueIsSanitized() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/v1/users", "POST");
+
+        // Server echoes the field name back but with the safe/sanitized value, not the submitted one
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"id\":5,\"name\":\"Dave\",\"isAdmin\":false,\"role\":\"user\"}"));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.stream().anyMatch(f -> f.getTitle().contains("Mass Assignment")),
+                "Should not flag mass assignment when the privileged value was sanitized, even if the key is echoed back");
+    }
+
+    /**
      * GET endpoints should be skipped by the mass-assignment check (only POST/PUT/PATCH apply).
      */
     @Test

--- a/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
@@ -3,6 +3,7 @@ package org.owasp.astf.testcases;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.owasp.astf.core.EndpointInfo;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -92,6 +94,22 @@ class GraphQLSecurityTestCaseTest {
         assertTrue(findings.isEmpty(), "No finding when introspection is disabled");
     }
 
+    @Test
+    @DisplayName("No false positive when a schema-validation error message happens to mention '__schema'")
+    void testIntrospectionDisabledNoFalsePositiveOnErrorMessageMentioningSchema() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        // Real-world error text from servers with introspection disabled — the literal
+        // substring "__schema" appears here even though introspection is OFF, which a naive
+        // body.contains("__schema") check would misread as introspection being enabled.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"errors\":[{\"message\":\"Cannot query field \\\"__schema\\\" on type \\\"Query\\\".\"}]}"));
+
+        List<Finding> findings = testCase.testIntrospectionEnabled(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(), "Should not flag introspection when the response is an error, even if it mentions __schema");
+    }
+
     // ── field suggestion leakage ──────────────────────────────────────────────
 
     @Test
@@ -153,6 +171,28 @@ class GraphQLSecurityTestCaseTest {
         List<Finding> findings = testCase.testQueryDepthAttack(endpoint, httpClient);
 
         assertTrue(findings.isEmpty(), "No finding when depth limit is enforced");
+    }
+
+    @Test
+    @DisplayName("Depth probe is built from real, always-valid schema fields, not guessed placeholder names")
+    void testDeepQueryUsesRealSchemaFields() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"data\":{\"__schema\":{\"types\":[]}}}"));
+
+        testCase.testQueryDepthAttack(endpoint, httpClient);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(httpClient).postWithStatus(anyString(), anyMap(), anyString(), bodyCaptor.capture());
+
+        String sentQuery = bodyCaptor.getValue();
+        // __Type.ofType is part of every spec-mandated introspection schema, so nesting it
+        // reaches real depth resolution instead of failing schema validation the way guessed
+        // placeholder field names ("a", "b", "c", ...) would on any real GraphQL server.
+        assertTrue(sentQuery.contains("ofType"), "Deep query should chain the always-valid __Type.ofType field");
+        assertFalse(sentQuery.matches(".*\\{\\s*a\\s*\\{\\s*b\\s*\\{.*"),
+                "Deep query should not use guessed placeholder field names like a/b/c");
     }
 
     // ── batch query ───────────────────────────────────────────────────────────

--- a/src/test/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GrpcEndpointDetectionTestCaseTest.java
@@ -115,7 +115,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointFound() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -131,7 +131,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointNotFound() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(notFound());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -145,7 +145,7 @@ class GrpcEndpointDetectionTestCaseTest {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
         // All probes succeed — but we should only get one finding
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectGrpcEndpoint(endpoint, httpClient);
@@ -158,7 +158,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectGrpcEndpointExceptionHandled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Connection refused"));
 
         assertDoesNotThrow(() -> testCase.detectGrpcEndpoint(endpoint, httpClient),
@@ -172,7 +172,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionEnabled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.detectServerReflection(endpoint, httpClient);
@@ -190,7 +190,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionNotEnabled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(notFound());
 
         List<Finding> findings = testCase.detectServerReflection(endpoint, httpClient);
@@ -203,7 +203,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testDetectServerReflectionExceptionHandled() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo", "POST");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Connection refused"));
 
         assertDoesNotThrow(() -> testCase.detectServerReflection(endpoint, httpClient),
@@ -218,7 +218,7 @@ class GrpcEndpointDetectionTestCaseTest {
         EndpointInfo endpoint = new EndpointInfo("/grpc.health.v1.Health/Check", "POST");
 
         // All probes (detection + reflection) respond with gRPC content-type
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenReturn(grpcResponse());
 
         List<Finding> findings = testCase.execute(endpoint, httpClient);
@@ -236,7 +236,7 @@ class GrpcEndpointDetectionTestCaseTest {
     void testExecuteExceptionHandledGracefully() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
 
-        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+        when(httpClient.postH2c(anyString(), anyMap(), anyString(), anyString()))
                 .thenThrow(new IOException("Network error"));
 
         assertDoesNotThrow(() -> testCase.execute(endpoint, httpClient),

--- a/src/test/java/org/owasp/astf/testcases/ImproperInventoryManagementTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/ImproperInventoryManagementTestCaseTest.java
@@ -88,6 +88,26 @@ class ImproperInventoryManagementTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should NOT flag deprecated version/shadow endpoints on an SPA/reverse-proxy HTML fallback (regression)")
+    void testNoOldVersionFindingOnHtmlFallback() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/v2/users", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        // A catch-all SPA/reverse-proxy returns 200 text/html for every guessed old-version
+        // or shadow path — this must not be read as a real deprecated/shadow endpoint.
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "<html><body>App</body></html>",
+                        Map.of("Content-Type", List.of("text/html"))));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(
+                findings.stream().anyMatch(f ->
+                        f.getTitle().contains("Deprecated") || f.getTitle().contains("Shadow")),
+                "Should not flag deprecated/shadow endpoints when the response is an HTML SPA fallback page");
+    }
+
+    @Test
     @DisplayName("Should return no findings when shadow/old version paths return 404")
     void testNoFindingWhenShadowPathReturns404() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/v2/users", "GET");
@@ -113,8 +133,13 @@ class ImproperInventoryManagementTestCaseTest {
         EndpointInfo endpoint = new EndpointInfo("/", "GET");
         endpoint.setBaseUrl("https://example.com");
 
-        // Documentation paths return 200 with OpenAPI spec content
-        when(httpClient.getWithStatus(anyString(), anyMap()))
+        // The fallback-baseline probe (a deliberately nonexistent path) returns 404/empty;
+        // real documentation paths return 200 with OpenAPI spec content. They must differ,
+        // otherwise the baseline-diff guard (added to avoid SPA-fallback false positives)
+        // would treat the doc content as "just the generic fallback page".
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.contains("__astf_nonexistent_path_check__")), anyMap()))
+                .thenReturn(notFound());
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.contains("__astf_nonexistent_path_check__")), anyMap()))
                 .thenReturn(ok("{\"openapi\":\"3.0.0\",\"paths\":{}}"));
 
         List<Finding> findings = testCase.execute(endpoint, httpClient);
@@ -124,6 +149,25 @@ class ImproperInventoryManagementTestCaseTest {
                 findings.stream().anyMatch(f -> f.getTitle().contains("Documentation")
                         || f.getTitle().contains("Exposed")),
                 "Finding should reference exposed documentation");
+    }
+
+    @Test
+    @DisplayName("Should NOT flag documentation exposure when every path returns the same SPA fallback page (regression)")
+    void testNoDocumentationFindingOnSpaFallback() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        // Every path, including the nonexistent-path baseline probe, returns the identical
+        // generic SPA shell — none of it is real documentation content.
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(ok("<html><body>App Shell</body></html>"));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(
+                findings.stream().anyMatch(f -> f.getTitle().contains("Documentation")
+                        || f.getTitle().contains("Exposed")),
+                "Should not report documentation exposure when the content is identical to the generic fallback page");
     }
 
     @Test

--- a/src/test/java/org/owasp/astf/testcases/SecurityMisconfigurationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/SecurityMisconfigurationTestCaseTest.java
@@ -137,6 +137,62 @@ class SecurityMisconfigurationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should flag conventionally-public endpoints (health/status/ping) as LOW, not HIGH")
+    void testConventionallyPublicEndpointGetsLowSeverity() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenAnswer(inv -> {
+                    String url = inv.getArgument(0);
+                    if (url.endsWith("/health")) {
+                        return new HttpResponse(200, "{\"status\":\"UP\"}", Map.of());
+                    }
+                    return new HttpResponse(404, "{}", Map.of());
+                });
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        findings.stream()
+                .filter(f -> f.getTitle().contains("Debug") && f.getEndpoint() != null && f.getEndpoint().contains("/health"))
+                .findFirst()
+                .ifPresentOrElse(
+                        f -> assertEquals(Severity.LOW, f.getSeverity(),
+                                "A conventionally-public health endpoint should be LOW severity, not HIGH"),
+                        () -> fail("Expected a finding for the /health endpoint"));
+    }
+
+    @Test
+    @DisplayName("Should NOT flag a generic error message that merely mentions 'key' without disclosing a value")
+    void testNoVerboseErrorFalsePositiveOnGenericMessage() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/data", "GET");
+        String genericError = "{\"error\":\"invalid API key\"}";
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(500, genericError, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Verbose")),
+                "Should not flag a generic 'invalid API key' message as verbose error disclosure");
+    }
+
+    @Test
+    @DisplayName("Should still flag a genuine disclosed credential value in an error message")
+    void testVerboseErrorStillDetectedForRealDisclosure() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/data", "GET");
+        String realDisclosure = "{\"error\":\"db connection failed\",\"password\": \"hunter2\"}";
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(500, realDisclosure, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Verbose")),
+                "Should still flag a genuine 'password: value' disclosure in an error response");
+    }
+
+    @Test
     @DisplayName("Should handle exceptions during testing")
     void testExceptionHandling() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/data", "GET");

--- a/src/test/java/org/owasp/astf/testcases/ServerSideRequestForgeryTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/ServerSideRequestForgeryTestCaseTest.java
@@ -64,8 +64,11 @@ class ServerSideRequestForgeryTestCaseTest {
         // GET endpoint — the test case exercises testQueryParameterSsrf
         EndpointInfo endpoint = new EndpointInfo("/api/fetch", "GET");
 
-        // Any GET call returns a body containing an SSRF indicator
-        when(httpClient.getWithStatus(anyString(), anyMap()))
+        // Baseline (no injected params, URL has no "=") is clean; only the payload-bearing
+        // probe URLs (which always append "?param=...") return the SSRF indicator.
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.contains("=")), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"data\":\"ok\"}", Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.contains("=")), anyMap()))
                 .thenReturn(new HttpResponse(200,
                         "{\"result\":\"ami-id: ami-0abcdef1234567890\"}",
                         Map.of()));
@@ -77,6 +80,23 @@ class ServerSideRequestForgeryTestCaseTest {
                 findings.stream().anyMatch(f -> f.getTitle().contains("SSRF")
                         || f.getTitle().contains("Server Side Request Forgery")),
                 "Finding title should reference SSRF");
+    }
+
+    @Test
+    @DisplayName("Should NOT flag SSRF when the indicator is already present in the baseline (unmodified) response")
+    void testNoSsrfWhenIndicatorAlreadyInBaseline() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/fetch", "GET");
+
+        // Every response — baseline AND payload-probe alike — mentions "docker", simulating an
+        // API that just happens to describe its own deployment environment. Since the word is
+        // already present without any injected payload, it must not be treated as SSRF evidence.
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"platform\":\"docker\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(),
+                "Should not flag SSRF when the indicator word is already present in the endpoint's normal response");
     }
 
     @Test

--- a/src/test/java/org/owasp/astf/testcases/UnrestrictedResourceConsumptionTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/UnrestrictedResourceConsumptionTestCaseTest.java
@@ -76,6 +76,100 @@ class UnrestrictedResourceConsumptionTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should detect rate limiting is missing even when a rejection is a 200 with a body message, not a 429 (regression)")
+    void testMissingRateLimitDetectedViaBodyEvenWithout429() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        // Every response is HTTP 200 with a normal-looking success body — genuinely no rate
+        // limiting anywhere, never a rejection of any kind.
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"users\":[]}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Rate Limiting")),
+                "Should still detect missing rate limiting when every response is a genuine 200 success");
+    }
+
+    @Test
+    @DisplayName("Should NOT flag missing rate limiting when a 200 response body signals rejection")
+    void testNoRateLimitFindingWhen200BodySignalsRejection() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        // Server returns HTTP 200 for every call, but explicitly says "rate limit exceeded" in
+        // the body instead of using a 429 status — this must still count as rate limiting working.
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"error\":\"rate limit exceeded, please slow down\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Rate Limiting")),
+                "Should not flag missing rate limiting when the body explicitly signals a rejection");
+    }
+
+    @Test
+    @DisplayName("Should flag missing pagination limit when a large page-size request returns a huge JSON array")
+    void testLargePaginationLimitMissing() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        String hugeArray = "[" + "{\"id\":1,\"name\":\"user\"},".repeat(60_000) + "{\"id\":2}]";
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, hugeArray, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Missing Pagination Limit")),
+                "Should flag missing pagination limit for an oversized JSON array response");
+    }
+
+    @Test
+    @DisplayName("Should NOT flag missing pagination limit when the large response isn't JSON data")
+    void testNoLargePaginationFindingForNonJsonBody() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        // A large HTML error/fallback page, not real API data
+        String hugeHtml = "<html><body>" + "error ".repeat(200_000) + "</body></html>";
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, hugeHtml, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Missing Pagination Limit")),
+                "Should not flag missing pagination limit for a large non-JSON (HTML) response");
+    }
+
+    @Test
+    @DisplayName("Should flag missing pagination metadata on a large collection response with no pagination indicators")
+    void testMissingPaginationMetadata() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        String hugeArrayNoMetadata = "[" + "{\"id\":1,\"name\":\"user\"},".repeat(6_000) + "{\"id\":2}]";
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, hugeArrayNoMetadata, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Missing Pagination on Collection")),
+                "Should flag missing pagination metadata for a large response with no pagination indicators");
+    }
+
+    @Test
+    @DisplayName("Should NOT flag missing pagination metadata when the response includes pagination fields")
+    void testNoMissingPaginationFindingWhenMetadataPresent() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+
+        String hugeArrayWithMetadata = "{\"total\":6000,\"page\":1,\"users\":[" +
+                "{\"id\":1,\"name\":\"user\"},".repeat(6_000) + "{\"id\":2}]}";
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, hugeArrayWithMetadata, Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Missing Pagination on Collection")),
+                "Should not flag missing pagination metadata when the response already includes pagination fields");
+    }
+
+    @Test
     @DisplayName("Should not test rate limiting on non-GET endpoints")
     void testSkipsNonGetForRateLimit() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "POST");

--- a/src/test/java/org/owasp/astf/testcases/UnsafeConsumptionOfApisTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/UnsafeConsumptionOfApisTestCaseTest.java
@@ -108,6 +108,25 @@ class UnsafeConsumptionOfApisTestCaseTest {
     }
 
     @Test
+    @DisplayName("Should detect SQL injection when a 500 response contains a database error (regression)")
+    void testSqlInjectionDetectedOn500() throws IOException {
+        // Error-based SQL injection almost always surfaces as a 500 with the raw DB error,
+        // not a 2xx — this must be detected even though the response is a server error.
+        EndpointInfo endpoint = new EndpointInfo("/api/webhook", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(500,
+                        "{\"error\":\"You have an error in your SQL syntax; check the manual that " +
+                        "corresponds to your MySQL server version\"}",
+                        Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("SQL Injection")),
+                "Should detect SQL injection from a 500 response containing a database error");
+    }
+
+    @Test
     @DisplayName("Should detect open redirect when Location header echoes attacker domain")
     void testOpenRedirectDetected() throws IOException {
         // GET endpoint — testOpenRedirect only fires on GET


### PR DESCRIPTION
## Summary
Found while gap-analyzing test-case coverage after the round-1 fixes (#70-74) landed — same class of defects, in the 9 test cases that hadn't been code-reviewed yet.

- **BOPLA (#80)**: mass-assignment check only verified the privileged key was *present* in the response, never checked its *value* — a correctly-sanitized `"isAdmin":false` still triggered a HIGH finding.
- **SSRF (#81)**: indicator words (`docker`, `kubernetes`) are generic enough to appear in any DevOps API's normal response, with no correlation back to the actual injected payload.
- **Improper Inventory Management (#82)**: missing the SPA/fallback content-type guard that BFLA already has elsewhere in the codebase — a catch-all reverse proxy returning 200 HTML for any path triggers false "deprecated version"/"shadow endpoint" findings.
- **BFLA (#83)**: the SPA-fallback guard *does* exist for the admin-path probe but was never applied to the HTTP-method-escalation check in the same file.
- **Security Misconfiguration (#84)**: `/health`, `/ping`, `/status` (intentionally public by convention) get the same HIGH severity as `/heapdump` or `/.env`; error-pattern words (`key`, `token`) are broad enough to flag routine error messages as "verbose."
- **Unsafe Consumption of APIs (#85)**: SQL-error indicators are only checked when the status is 2xx — but real error-based SQL injection almost always returns 500 with the DB error text, making the most common real-world signal unreachable.
- **Unrestricted Resource Consumption (#86)**: same status-only blindness as the others; two whole code paths (large-pagination, missing-pagination-metadata) had zero unit test coverage.

## Test plan
- [x] Existing + new unit tests pass (241 tests)
- [x] Each fix backed by a regression test using a realistic response shape (not just the happy-path mock)

Fixes #80, #81, #82, #83, #84, #85, #86