### PR TITLE
docs: bring the public OWASP project page (index.md) up to date

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,39 +12,44 @@ pitch: A comprehensive automated testing framework for detecting API security vu
 
 ## Description
 
-The OWASP API Security Testing Framework (ASTF) is a specialized security testing tool designed to automatically detect vulnerabilities in APIs based on the **OWASP API Security Top 10 2023**. It discovers endpoints automatically, runs 12 security test cases covering the full Top 10 plus GraphQL and gRPC, and produces findings in JSON, HTML, SARIF, and XML formats.
+The OWASP API Security Testing Framework (ASTF) is a specialized security testing tool designed to automatically detect vulnerabilities in APIs based on the **OWASP API Security Top 10 2023**. It discovers endpoints automatically, runs 16 security test cases covering the full Top 10 plus GraphQL, gRPC, mutual TLS, LLM/chatbot, and general injection testing, and produces findings in JSON, HTML, SARIF, and XML formats.
 
 **Current release: [v1.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)**
 
-ASTF has been validated against [OWASP crAPI](https://github.com/OWASP/crAPI) — the intentionally vulnerable API — where it auto-discovered 832 endpoints and detected 11 distinct vulnerability types including JWT algorithm weaknesses, missing authentication controls, and improper inventory management.
+ASTF has been validated against real, intentionally-vulnerable API targets — [OWASP crAPI](https://github.com/OWASP/crAPI), [VAmPI](https://github.com/erev0s/VAmPI), and [DVGA](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) — with findings live-verified against the actual running applications, not just unit tests. That verification confirmed real exploitable conditions: a genuine cross-user account takeover (one identity changing another's password with no ownership check) and a genuine privilege escalation (a non-admin token succeeding on an unprotected admin-tier sibling endpoint) against the public crAPI demo, among others.
 
 ## Key Features
 
 - **100% OWASP API Security Top 10 2023 coverage** — all 10 categories implemented and tested
-- **12 security test cases** — API1 through API10, plus dedicated GraphQL and gRPC checks
+- **16 security test cases** — API1 through API10, plus GraphQL, gRPC, mutual TLS, LLM prompt injection, general SQL/NoSQL injection, and ReDoS
+- **Cross-user authorization testing** — provide two distinct authenticated identities and ASTF checks whether one can access or modify the other's objects on the identical URL, with no ID guessing involved. This is the strongest evidence class the framework produces, and it has confirmed real account-takeover-class vulnerabilities in live testing.
 - **Auto endpoint discovery** — finds endpoints via OpenAPI/Swagger probing and common path patterns; zero config required for a first scan
-- **Multiple auth modes** — Bearer token, API key, Basic auth, custom headers
+- **Multiple auth modes** — Bearer token (including a second, distinct identity for cross-user testing), API key, Basic auth, mutual TLS client certificates, custom headers
 - **Four output formats** — HTML (human review), JSON (processing), SARIF (GitHub Code Scanning), XML
 - **CI/CD ready** — GitHub Actions workflow included; exits with code `1` when findings detected for pipeline gating
-- **229 passing unit tests** — fully test-covered implementation
-- **Proven on real targets** — validated against OWASP crAPI public demo
+- **350 passing unit tests** — fully test-covered implementation
+- **Proven on real targets, with an honest scorecard** — validated against OWASP crAPI, VAmPI, and DVGA, with a public traceability matrix showing exactly what is and isn't detected against each target's own documented vulnerability list, not just an unqualified "100% coverage" claim
 
 ## Test Case Coverage
 
 | ID | Vulnerability | What It Detects |
 |---|---|---|
-| ASTF-API1-2023 | Broken Object Level Authorization | BOLA/IDOR via ID manipulation |
-| ASTF-API2-2023 | Broken Authentication | Missing auth, JWT `none` algorithm, expired tokens, 2FA bypass |
+| ASTF-API1-2023 | Broken Object Level Authorization | BOLA/IDOR via ID manipulation, plus cross-user access confirmation with two distinct identities |
+| ASTF-API2-2023 | Broken Authentication | Missing auth, JWT `none`/`kid`-traversal/algorithm-confusion/`jku` attacks, username enumeration, brute-force lockout, 2FA bypass |
 | ASTF-API3-2023 | Broken Object Property Level Authorization | Sensitive fields in responses, mass assignment |
-| ASTF-API4-2023 | Unrestricted Resource Consumption | Missing rate limiting headers |
-| ASTF-API5-2023 | Broken Function Level Authorization | Admin endpoints accessible without privileges |
+| ASTF-API4-2023 | Unrestricted Resource Consumption | Missing rate limiting (burst-request test) |
+| ASTF-API5-2023 | Broken Function Level Authorization | Admin endpoints accessible without privileges, HTTP method escalation, and privilege-tier path substitution (e.g. `/user/...` → `/admin/...` on an otherwise identical request) |
 | ASTF-API6-2023 | Unrestricted Access to Sensitive Flows | Missing bot protection on login/OTP/payment flows |
 | ASTF-API7-2023 | Server-Side Request Forgery | SSRF via URL/webhook/redirect parameters |
 | ASTF-API8-2023 | Security Misconfiguration | Missing security headers, verbose errors |
 | ASTF-API9-2023 | Improper Inventory Management | Deprecated versions, shadow endpoints, exposed docs |
 | ASTF-API10-2023 | Unsafe Consumption of APIs | Injection via integration endpoints, open redirect |
-| ASTF-GRAPHQL-2023 | GraphQL Security | Introspection, field suggestions, depth attacks, batch abuse |
-| ASTF-GRPC-2023 | gRPC Endpoint Detection | Service detection, server reflection enabled |
+| ASTF-GRAPHQL-2023 | GraphQL Security | Introspection, field suggestions, 5 denial-of-service variants, resolver injection across every mutation/query field, GraphiQL exposure, deny-list bypass, auth bypass, brute-force, stack-trace disclosure |
+| ASTF-GRPC-2023 | gRPC Endpoint Detection | Service detection over h2c, server reflection enabled, scoped injection testing |
+| ASTF-MTLS-2023 | Mutual TLS Validation | Whether the server actually validates client certificate trust chains |
+| ASTF-LLM-2023 | LLM Prompt Injection | Prompt injection against LLM/chatbot-backed endpoints |
+| ASTF-INJECTION-2023 | SQL/NoSQL Injection | General-purpose SQL/NoSQL injection on REST body fields and path parameters |
+| ASTF-REDOS-2023 | Regular Expression Denial of Service | Catastrophic-backtracking payloads, detected via response-time baseline comparison |
 
 ## Getting Started
 
@@ -66,10 +71,10 @@ Or build from source:
 git clone https://github.com/OWASP/www-project-api-security-testing-framework.git
 cd www-project-api-security-testing-framework
 mvn clean package -DskipTests
-java -jar target/api-security-testing-framework-1.0-SNAPSHOT.jar -u https://api.example.com
+java -jar target/api-security-testing-framework-1.0.0.jar -u https://api.example.com
 ```
 
-For full documentation see the [GitHub repository](https://github.com/OWASP/www-project-api-security-testing-framework).
+For methodology — what to test, how to interpret results, how to avoid false positives — see the [Testing Guidelines](https://github.com/OWASP/www-project-api-security-testing-framework/blob/main/docs/TESTING_GUIDELINES.md). For full documentation see the [GitHub repository](https://github.com/OWASP/www-project-api-security-testing-framework).
 
 ## CI/CD Integration
 
@@ -107,13 +112,24 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
 ### ✅ Phase 3 — Beta Release (Completed Q2 2026)
 - Automated release workflow — JAR published to GitHub Releases on version tags
 - `v1.0.0` released with pre-built downloadable JAR
-- Full OWASP project page update
 
-### 🔜 Phase 4 — Stable Release (Planned)
+### ✅ Phase 4 — Depth & Real-World Verification (Completed)
+- Cross-user authorization testing — a second identity (`--secondary-token`) checked against the first for BOLA, the strongest evidence class the framework produces
+- Broken Function Level Authorization: HTTP method escalation and privilege-tier path substitution (`/user/...` → `/admin/...`)
+- JWT attack depth: `kid` path traversal, RS256→HS256 algorithm confusion, `jku` header abuse, username enumeration, brute-force lockout detection
+- Mutual TLS client-certificate validation testing
+- LLM/chatbot prompt injection testing
+- General-purpose SQL/NoSQL injection and Regular Expression Denial of Service (ReDoS) test cases
+- GraphQL depth: resolver injection across every mutation/query field (not just the first few), 3 additional denial-of-service variants, GraphiQL/IDE exposure, deny-list bypass, argument-based auth bypass, login brute-force, stack-trace disclosure
+- Live verification against real running vulnerable applications (crAPI, VAmPI, DVGA) with a published traceability matrix tracing every finding back to each target's own documented vulnerability list
+- Comprehensive [Testing Guidelines](https://github.com/OWASP/www-project-api-security-testing-framework/blob/main/docs/TESTING_GUIDELINES.md) covering methodology, result interpretation, and false-positive reduction
+
+### 🔜 Phase 5 — Stable Release (Planned)
 - OpenAPI/Swagger spec import for precise endpoint targeting
 - Plugin system for custom test cases
 - Distributed scanning for large API surfaces
 - Integration with vulnerability management platforms (Defect Dojo, Jira)
+- Multi-step business-logic flow testing (e.g. chained requests where a vulnerable endpoint is only reachable via a value returned by an earlier call)
 
 ## Getting Involved
 
@@ -127,7 +143,9 @@ The API Security Testing Framework welcomes community contributions:
 ## Related Projects
 
 - [OWASP API Security Project](https://owasp.org/www-project-api-security/) — The Top 10 standard this framework implements
-- [OWASP crAPI](https://github.com/OWASP/crAPI) — Intentionally vulnerable API for testing
+- [OWASP crAPI](https://github.com/OWASP/crAPI) — Intentionally vulnerable API used for live verification
+- [VAmPI](https://github.com/erev0s/VAmPI) — Intentionally vulnerable API used for live verification
+- [DVGA](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) — Intentionally vulnerable GraphQL application used for live verification
 - [OWASP ZAP](https://www.zaproxy.org) — Complementary web application scanner
 
 ## Licensing


### PR DESCRIPTION
## Summary

`index.md` at the repo root is the source the OWASP site (https://owasp.org/www-project-api-security-testing-framework/) renders directly — I checked the live page against this file and confirmed it's a verbatim match. It was still describing the original v1.0.0-launch state: 12 test cases, 229 tests, no mention of anything that's shipped since.

Fixes:
- **Test case catalog**: 12 → 16. Added mTLS, LLM prompt injection, general SQL/NoSQL injection, and ReDoS, which weren't mentioned at all. Refreshed BOLA/BFLA/GraphQL entries to describe cross-user authorization testing, privilege-tier path substitution, and the expanded GraphQL check set (resolver injection across every field, 3 more DoS variants, GraphiQL exposure, deny-list bypass, etc.) — these existed in the tool but weren't described anywhere on the public page.
- **Test count**: 229 → 350.
- **Key Features**: added cross-user authorization testing and mutual TLS as their own bullets — these are two of the framework's most distinctive capabilities and weren't mentioned at all.
- **Coverage framing**: replaced the unqualified "100% coverage" framing with a mention of the published traceability matrix (what's verified against real targets vs. what honestly isn't yet) — this is the same "don't overclaim" principle already applied to the README's messaging.
- **Build-from-source jar path**: was `target/api-security-testing-framework-1.0-SNAPSHOT.jar`, which doesn't match the current `pom.xml` version (`1.0.0`) — fixed.
- **Roadmap**: added a "Phase 4 — Depth & Real-World Verification" entry documenting everything that's shipped since the original v1.0.0 launch (JWT attack depth, mTLS, LLM, general injection, ReDoS, GraphQL depth, live verification against crAPI/VAmPI/DVGA with a public traceability matrix), and moved the genuinely-still-outstanding items into a renumbered Phase 5.
- **Related Projects**: added VAmPI and DVGA alongside crAPI, since all three are now used for live verification.
- Linked the new Testing Guidelines doc (#105) from the Getting Started section.

## Test plan

- [x] Documentation-only change (`index.md`), no code touched
- [x] Fetched the live OWASP page and confirmed it renders this file verbatim before making changes
- [x] Cross-checked every test case ID/count against the current `TestCaseRegistry` and test suite
- [x] Cross-checked the jar path against the current `pom.xml` version