### PR TITLE
chore(release): prepare v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,11 @@ jobs:
             - Java 21+
 
             ### What's included
-            - 12 security test cases — full OWASP API Security Top 10 2023 + GraphQL + gRPC
+            - 16 security test cases — full OWASP API Security Top 10 2023 + GraphQL, gRPC, mutual TLS, LLM prompt injection, general SQL/NoSQL injection, and ReDoS
+            - Cross-user authorization testing (`--secondary-token`) for BOLA, mutual TLS client-certificate validation
             - Output formats: JSON, HTML, SARIF, XML
             - Auto endpoint discovery
-            - 235 passing unit tests
+            - 350 passing unit tests
 
             See the [README](https://github.com/OWASP/www-project-api-security-testing-framework#readme)
             and [docs/](https://github.com/OWASP/www-project-api-security-testing-framework/tree/main/docs)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A comprehensive automated testing framework for detecting API security vulnerabi
 Download the latest pre-built JAR directly from the [GitHub Releases page](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest) — no build step needed:
 
 ```bash
-# Download the latest beta release
-curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v1.0.0.jar
+# Download the latest stable release
+curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
 ```
 
 Or build from source:
@@ -34,14 +34,14 @@ Or build from source:
 git clone https://github.com/OWASP/www-project-api-security-testing-framework.git
 cd www-project-api-security-testing-framework
 mvn clean package -DskipTests
-# JAR is at: target/api-security-testing-framework-1.0.0.jar
+# JAR is at: target/api-security-testing-framework-2.0.0.jar
 ```
 
 ### 3. Run your first scan (copy-paste ready)
 
 **Option A — Inline flags** (quickest):
 ```bash
-java -jar astf-v1.0.0.jar \
+java -jar astf-v2.0.0.jar \
   -u https://api.example.com \
   --token "YOUR_BEARER_TOKEN" \
   -f HTML -o results.html -v
@@ -49,12 +49,12 @@ java -jar astf-v1.0.0.jar \
 
 **Option B — Config file** (recommended for repeatable scans):
 ```bash
-java -jar astf-v1.0.0.jar -c docs/examples/scan-config.yaml
+java -jar astf-v2.0.0.jar -c docs/examples/scan-config.yaml
 ```
 
 **Option C — Against OWASP crAPI** (zero-config proof of concept):
 ```bash
-java -jar astf-v1.0.0.jar \
+java -jar astf-v2.0.0.jar \
   -u http://crapi.apisec.ai \
   -f HTML -o crapi-report.html --timeout 3
 # Auto-discovers 832 endpoints, detects 11 vulnerability types
@@ -77,13 +77,13 @@ Releases are published automatically when a version tag is pushed. The workflow 
 
 | Tag format | Release type | Example |
 |---|---|---|
-| `v*-beta` | Pre-release | `v1.0.0-beta` |
-| `v*-rc*` | Release candidate | `v1.0.0-rc1` |
-| `v*` (no suffix) | Stable release | `v1.0.0` ← current |
+| `v*-beta` | Pre-release | `v2.0.0-beta` |
+| `v*-rc*` | Release candidate | `v2.0.0-rc1` |
+| `v*` (no suffix) | Stable release | `v2.0.0` ← current |
 
 **[→ View all releases](https://github.com/OWASP/www-project-api-security-testing-framework/releases)**
 
-The JAR asset on each release is named `astf-<tag>.jar`, e.g. `astf-v1.0.0.jar`. Use this name in your CI pipelines to pin a specific version.
+The JAR asset on each release is named `astf-<tag>.jar`, e.g. `astf-v2.0.0.jar`. Use this name in your CI pipelines to pin a specific version.
 
 ---
 
@@ -190,7 +190,7 @@ When multiple endpoint sources are configured, ASTF uses this order (highest win
 
 ```bash
 # Scan only specific endpoints from a file
-java -jar astf-v1.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.0.jar -u https://api.example.com \
   --endpoints-file my-endpoints.txt --token "TOKEN"
 
 # my-endpoints.txt format:
@@ -235,10 +235,10 @@ java -jar astf-v1.0.0.jar -u https://api.example.com \
 
 Run only specific test cases:
 ```bash
-java -jar astf-v1.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.0.jar -u https://api.example.com \
   --test-cases ASTF-API1-2023,ASTF-API2-2023
 
-java -jar astf-v1.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.0.jar -u https://api.example.com \
   --exclude-tests ASTF-GRAPHQL-2023,ASTF-GRPC-2023
 ```
 
@@ -305,11 +305,11 @@ jobs:
 
       - name: Download ASTF
         run: |
-          curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v1.0.0.jar
+          curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
 
       - name: Run ASTF scan
         run: |
-          java -jar astf-v1.0.0.jar \
+          java -jar astf-v2.0.0.jar \
             -u ${{ secrets.API_URL }} \
             --token ${{ secrets.API_TOKEN }} \
             -f SARIF -o results.sarif \
@@ -332,7 +332,7 @@ jobs:
 ### Gate on HIGH/CRITICAL only (not every finding)
 
 ```bash
-java -jar astf-v1.0.0.jar \
+java -jar astf-v2.0.0.jar \
   -u $API_URL --token $TOKEN -f JSON -o results.json
 
 HIGH_CRIT=$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' results.json)
@@ -407,12 +407,14 @@ To add a new test case, see [Adding New Test Cases](docs/ARCHITECTURE.md#adding-
 ```bash
 # 1. Ensure main is green (all CI checks pass)
 # 2. Tag and push — the release workflow does everything else
-git tag v1.0.0
-git push origin v1.0.0
+git tag v2.0.0
+git push origin v2.0.0
 ```
 
-The `release.yml` workflow will run all 350 tests, build `astf-v1.0.0.jar`,
-create a GitHub Release marked as pre-release, and attach the JAR as a downloadable asset.
+The `release.yml` workflow will run all 350 tests, build `astf-v2.0.0.jar`, and create a
+GitHub Release with the JAR attached as a downloadable asset. A plain `vX.Y.Z` tag (no
+`alpha`/`beta`/`rc` suffix) is published as a **stable** release; only tags matching one of
+those suffixes are marked as a pre-release — see the [tag format table](#releases) above.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -145,12 +145,12 @@ The release workflow runs the full test suite before building the JAR. If any of
 
 ```bash
 # Delete tag locally and remotely, then re-push after the fix
-git tag -d v1.0.0
-git push origin :refs/tags/v1.0.0
+git tag -d v2.0.0
+git push origin :refs/tags/v2.0.0
 
 # After fixing and merging to main:
-git tag v1.0.0
-git push origin v1.0.0
+git tag v2.0.0
+git push origin v2.0.0
 ```
 
 ---
@@ -183,11 +183,11 @@ java -version   # must show 21 or higher
 
 ## Reporting Issues
 
-This is a **beta release** — we actively want your feedback.
+We actively want your feedback.
 
 ### Bug Reports
 Use the [Bug Report template](../.github/ISSUE_TEMPLATE/bug_report.md). Include:
-- ASTF version (`java -jar astf-v1.0.0.jar -V`)
+- ASTF version (`java -jar astf-v2.0.0.jar -V`)
 - Java version (`java -version`)
 - The exact command you ran (redact any tokens)
 - Relevant output from `astf-scan.log`

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ pitch: A comprehensive automated testing framework for detecting API security vu
 
 The OWASP API Security Testing Framework (ASTF) is a specialized security testing tool designed to automatically detect vulnerabilities in APIs based on the **OWASP API Security Top 10 2023**. It discovers endpoints automatically, runs 16 security test cases covering the full Top 10 plus GraphQL, gRPC, mutual TLS, LLM/chatbot, and general injection testing, and produces findings in JSON, HTML, SARIF, and XML formats.
 
-**Current release: [v1.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)**
+**Current release: [v2.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)**
 
 ASTF has been validated against real, intentionally-vulnerable API targets — [OWASP crAPI](https://github.com/OWASP/crAPI), [VAmPI](https://github.com/erev0s/VAmPI), and [DVGA](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) — with findings live-verified against the actual running applications, not just unit tests. That verification confirmed real exploitable conditions: a genuine cross-user account takeover (one identity changing another's password with no ownership check) and a genuine privilege escalation (a non-admin token succeeding on an unprotected admin-tier sibling endpoint) against the public crAPI demo, among others.
 
@@ -57,13 +57,13 @@ ASTF has been validated against real, intentionally-vulnerable API targets — [
 
 ```bash
 # Download the latest release
-curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v1.0.0.jar
+curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
 
 # Run against your API
-java -jar astf-v1.0.0.jar -u https://api.example.com --token "YOUR_TOKEN" -f HTML -o report.html
+java -jar astf-v2.0.0.jar -u https://api.example.com --token "YOUR_TOKEN" -f HTML -o report.html
 
 # Try against OWASP crAPI (zero config needed)
-java -jar astf-v1.0.0.jar -u http://crapi.apisec.ai -f HTML -o crapi-report.html
+java -jar astf-v2.0.0.jar -u http://crapi.apisec.ai -f HTML -o crapi-report.html
 ```
 
 Or build from source:
@@ -71,7 +71,7 @@ Or build from source:
 git clone https://github.com/OWASP/www-project-api-security-testing-framework.git
 cd www-project-api-security-testing-framework
 mvn clean package -DskipTests
-java -jar target/api-security-testing-framework-1.0.0.jar -u https://api.example.com
+java -jar target/api-security-testing-framework-2.0.0.jar -u https://api.example.com
 ```
 
 For methodology — what to test, how to interpret results, how to avoid false positives — see the [Testing Guidelines](https://github.com/OWASP/www-project-api-security-testing-framework/blob/main/docs/TESTING_GUIDELINES.md). For full documentation see the [GitHub repository](https://github.com/OWASP/www-project-api-security-testing-framework).
@@ -82,10 +82,10 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
 
 ```yaml
 - name: Download ASTF
-  run: curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v1.0.0.jar
+  run: curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
 
 - name: Run security scan
-  run: java -jar astf-v1.0.0.jar -u ${{ secrets.API_URL }} --token ${{ secrets.API_TOKEN }} -f SARIF -o results.sarif
+  run: java -jar astf-v2.0.0.jar -u ${{ secrets.API_URL }} --token ${{ secrets.API_TOKEN }} -f SARIF -o results.sarif
 
 - name: Upload to Code Scanning
   uses: github/codeql-action/upload-sarif@v3
@@ -124,12 +124,31 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
 - Live verification against real running vulnerable applications (crAPI, VAmPI, DVGA) with a published traceability matrix tracing every finding back to each target's own documented vulnerability list
 - Comprehensive [Testing Guidelines](https://github.com/OWASP/www-project-api-security-testing-framework/blob/main/docs/TESTING_GUIDELINES.md) covering methodology, result interpretation, and false-positive reduction
 
-### 🔜 Phase 5 — Stable Release (Planned)
-- OpenAPI/Swagger spec import for precise endpoint targeting
-- Plugin system for custom test cases
-- Distributed scanning for large API surfaces
-- Integration with vulnerability management platforms (Defect Dojo, Jira)
-- Multi-step business-logic flow testing (e.g. chained requests where a vulnerable endpoint is only reachable via a value returned by an earlier call)
+### ✅ Phase 5 — v2.0.0 Stable Release (Completed)
+- Version bumped to 2.0.0, reflecting the growth from 1 to 16 test cases, cross-user
+  authorization testing, mutual TLS/LLM/general-injection/ReDoS coverage, GraphQL depth,
+  and live-verified findings against real vulnerable applications since v1.0.0
+- Comprehensive Testing Guidelines and a full documentation refresh
+
+### 🔜 Phase 6 — Real-World Pen-Testing Utility (Planned)
+- **Multi-step business-logic flow testing** — chained requests where a vulnerable endpoint
+  is only reachable via a value returned by an earlier call (e.g. crAPI's mechanic-report
+  BOLA, only discoverable through a link embedded in a prior response)
+- **Plugin system for custom test cases** — let the community publish and share their own
+  checks without needing a core-repo review cycle for every addition
+- OpenAPI/Swagger and GraphQL SDL spec import for precise, guess-free endpoint/schema
+  targeting instead of pattern-guessed discovery
+- Automated login-flow support — configure a credential-submission sequence once instead of
+  pasting a pre-fetched token into every run
+- Findings baseline/suppression — accept a known, risk-accepted finding once instead of
+  re-flagging it on every CI run
+- `--dry-run`/safe-mode for state-changing checks — live testing has already proven the
+  cross-user BOLA check can cause a real password change or resource deletion, not just a
+  2xx response; anyone running this against anything sensitive needs an explicit control
+- Distributed scanning for large API surfaces, and integration with vulnerability management
+  platforms (Defect Dojo, Jira) — both scoped as thin, optional integrations rather than new
+  subsystems, to keep the project a security-testing engine rather than a security-operations
+  platform
 
 ## Getting Involved
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.owasp</groupId>
     <artifactId>api-security-testing-framework</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>OWASP API Security Testing Framework</name>


### PR DESCRIPTION
## Summary

Version bump and release-facing cleanup ahead of tagging `v2.0.0`.

- `pom.xml`: `1.0.0` → `2.0.0`
- `release.yml`: release-notes template updated from "12 test cases / 235 tests" to "16 test cases / 350 tests" (stale since well before this version), now calls out cross-user authorization testing and mTLS explicitly
- `README.md` / `index.md`: all `astf-v1.0.0.jar` and build-output jar path references bumped to `v2.0.0`; "latest beta release" corrected to "stable release"
- Fixed an actual inaccuracy in README's "Cutting a Release" section: it claimed a plain `vX.Y.Z` tag gets marked as a GitHub pre-release, but `release.yml`'s own logic only marks `alpha`/`beta`/`rc`-suffixed tags as pre-release — the wording now matches the workflow's actual behavior
- `index.md` roadmap: the "Stable Release" phase is now "**Phase 5 — v2.0.0 Stable Release (Completed)**" — scoped to what this version bump actually represents, not the unrelated OpenAPI-import/plugin-system/etc. items that were previously listed under that name. Those items move to a new **Phase 6 — Real-World Pen-Testing Utility**, reordered to lead with multi-step business-logic flow testing and a plugin system (the two most likely to grow both users and contributors), with distributed scanning and DefectDojo/Jira integration explicitly scoped as thin, optional integrations rather than new subsystems
- `docs/TROUBLESHOOTING.md`: version examples bumped, removed the stale "this is a beta release" framing

## Test plan

- [x] 350/350 tests passing after the version bump
- [x] Confirmed the shaded-jar build has no hardcoded version string (derives from `artifactId`+`version`, matching how `release.yml` already resolves the JAR name dynamically via `mvn help:evaluate`)
- [x] Swept README/index.md/TROUBLESHOOTING for every `1.0.0`/`beta` reference; left historical roadmap mentions (e.g. "Phase 3: `v1.0.0` released...") unchanged since they're accurate statements about the past, not the current release

Once merged, I'll tag `v2.0.0` on `main` and push it to trigger the release workflow.