### PR TITLE
chore(release): prepare v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download the latest pre-built JAR directly from the [GitHub Releases page](https
 
 ```bash
 # Download the latest stable release
-curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
+curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.1.jar
 ```
 
 Or build from source:
@@ -34,14 +34,14 @@ Or build from source:
 git clone https://github.com/OWASP/www-project-api-security-testing-framework.git
 cd www-project-api-security-testing-framework
 mvn clean package -DskipTests
-# JAR is at: target/api-security-testing-framework-2.0.0.jar
+# JAR is at: target/api-security-testing-framework-2.0.1.jar
 ```
 
 ### 3. Run your first scan (copy-paste ready)
 
 **Option A — Inline flags** (quickest):
 ```bash
-java -jar astf-v2.0.0.jar \
+java -jar astf-v2.0.1.jar \
   -u https://api.example.com \
   --token "YOUR_BEARER_TOKEN" \
   -f HTML -o results.html -v
@@ -49,12 +49,12 @@ java -jar astf-v2.0.0.jar \
 
 **Option B — Config file** (recommended for repeatable scans):
 ```bash
-java -jar astf-v2.0.0.jar -c docs/examples/scan-config.yaml
+java -jar astf-v2.0.1.jar -c docs/examples/scan-config.yaml
 ```
 
 **Option C — Against OWASP crAPI** (zero-config proof of concept):
 ```bash
-java -jar astf-v2.0.0.jar \
+java -jar astf-v2.0.1.jar \
   -u http://crapi.apisec.ai \
   -f HTML -o crapi-report.html --timeout 3
 # Auto-discovers 832 endpoints, detects 11 vulnerability types
@@ -77,13 +77,13 @@ Releases are published automatically when a version tag is pushed. The workflow 
 
 | Tag format | Release type | Example |
 |---|---|---|
-| `v*-beta` | Pre-release | `v2.0.0-beta` |
-| `v*-rc*` | Release candidate | `v2.0.0-rc1` |
-| `v*` (no suffix) | Stable release | `v2.0.0` ← current |
+| `v*-beta` | Pre-release | `v2.0.1-beta` |
+| `v*-rc*` | Release candidate | `v2.0.1-rc1` |
+| `v*` (no suffix) | Stable release | `v2.0.1` ← current |
 
 **[→ View all releases](https://github.com/OWASP/www-project-api-security-testing-framework/releases)**
 
-The JAR asset on each release is named `astf-<tag>.jar`, e.g. `astf-v2.0.0.jar`. Use this name in your CI pipelines to pin a specific version.
+The JAR asset on each release is named `astf-<tag>.jar`, e.g. `astf-v2.0.1.jar`. Use this name in your CI pipelines to pin a specific version.
 
 ---
 
@@ -190,7 +190,7 @@ When multiple endpoint sources are configured, ASTF uses this order (highest win
 
 ```bash
 # Scan only specific endpoints from a file
-java -jar astf-v2.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.1.jar -u https://api.example.com \
   --endpoints-file my-endpoints.txt --token "TOKEN"
 
 # my-endpoints.txt format:
@@ -235,10 +235,10 @@ java -jar astf-v2.0.0.jar -u https://api.example.com \
 
 Run only specific test cases:
 ```bash
-java -jar astf-v2.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.1.jar -u https://api.example.com \
   --test-cases ASTF-API1-2023,ASTF-API2-2023
 
-java -jar astf-v2.0.0.jar -u https://api.example.com \
+java -jar astf-v2.0.1.jar -u https://api.example.com \
   --exclude-tests ASTF-GRAPHQL-2023,ASTF-GRPC-2023
 ```
 
@@ -305,11 +305,11 @@ jobs:
 
       - name: Download ASTF
         run: |
-          curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
+          curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.1.jar
 
       - name: Run ASTF scan
         run: |
-          java -jar astf-v2.0.0.jar \
+          java -jar astf-v2.0.1.jar \
             -u ${{ secrets.API_URL }} \
             --token ${{ secrets.API_TOKEN }} \
             -f SARIF -o results.sarif \
@@ -332,7 +332,7 @@ jobs:
 ### Gate on HIGH/CRITICAL only (not every finding)
 
 ```bash
-java -jar astf-v2.0.0.jar \
+java -jar astf-v2.0.1.jar \
   -u $API_URL --token $TOKEN -f JSON -o results.json
 
 HIGH_CRIT=$(jq '[.findings[] | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' results.json)
@@ -407,11 +407,11 @@ To add a new test case, see [Adding New Test Cases](docs/ARCHITECTURE.md#adding-
 ```bash
 # 1. Ensure main is green (all CI checks pass)
 # 2. Tag and push — the release workflow does everything else
-git tag v2.0.0
-git push origin v2.0.0
+git tag v2.0.1
+git push origin v2.0.1
 ```
 
-The `release.yml` workflow will run all 350 tests, build `astf-v2.0.0.jar`, and create a
+The `release.yml` workflow will run all 350 tests, build `astf-v2.0.1.jar`, and create a
 GitHub Release with the JAR attached as a downloadable asset. A plain `vX.Y.Z` tag (no
 `alpha`/`beta`/`rc` suffix) is published as a **stable** release; only tags matching one of
 those suffixes are marked as a pre-release — see the [tag format table](#releases) above.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -145,12 +145,12 @@ The release workflow runs the full test suite before building the JAR. If any of
 
 ```bash
 # Delete tag locally and remotely, then re-push after the fix
-git tag -d v2.0.0
-git push origin :refs/tags/v2.0.0
+git tag -d v2.0.1
+git push origin :refs/tags/v2.0.1
 
 # After fixing and merging to main:
-git tag v2.0.0
-git push origin v2.0.0
+git tag v2.0.1
+git push origin v2.0.1
 ```
 
 ---
@@ -187,7 +187,7 @@ We actively want your feedback.
 
 ### Bug Reports
 Use the [Bug Report template](../.github/ISSUE_TEMPLATE/bug_report.md). Include:
-- ASTF version (`java -jar astf-v2.0.0.jar -V`)
+- ASTF version (`java -jar astf-v2.0.1.jar -V`)
 - Java version (`java -version`)
 - The exact command you ran (redact any tokens)
 - Relevant output from `astf-scan.log`

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ pitch: A comprehensive automated testing framework for detecting API security vu
 
 The OWASP API Security Testing Framework (ASTF) is a specialized security testing tool designed to automatically detect vulnerabilities in APIs based on the **OWASP API Security Top 10 2023**. It discovers endpoints automatically, runs 16 security test cases covering the full Top 10 plus GraphQL, gRPC, mutual TLS, LLM/chatbot, and general injection testing, and produces findings in JSON, HTML, SARIF, and XML formats.
 
-**Current release: [v2.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)**
+**Current release: [v2.0.1](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)**
 
 ASTF has been validated against real, intentionally-vulnerable API targets — [OWASP crAPI](https://github.com/OWASP/crAPI), [VAmPI](https://github.com/erev0s/VAmPI), and [DVGA](https://github.com/dolevf/Damn-Vulnerable-GraphQL-Application) — with findings live-verified against the actual running applications, not just unit tests. That verification confirmed real exploitable conditions: a genuine cross-user account takeover (one identity changing another's password with no ownership check) and a genuine privilege escalation (a non-admin token succeeding on an unprotected admin-tier sibling endpoint) against the public crAPI demo, among others.
 
@@ -57,13 +57,13 @@ ASTF has been validated against real, intentionally-vulnerable API targets — [
 
 ```bash
 # Download the latest release
-curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
+curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.1.jar
 
 # Run against your API
-java -jar astf-v2.0.0.jar -u https://api.example.com --token "YOUR_TOKEN" -f HTML -o report.html
+java -jar astf-v2.0.1.jar -u https://api.example.com --token "YOUR_TOKEN" -f HTML -o report.html
 
 # Try against OWASP crAPI (zero config needed)
-java -jar astf-v2.0.0.jar -u http://crapi.apisec.ai -f HTML -o crapi-report.html
+java -jar astf-v2.0.1.jar -u http://crapi.apisec.ai -f HTML -o crapi-report.html
 ```
 
 Or build from source:
@@ -71,7 +71,7 @@ Or build from source:
 git clone https://github.com/OWASP/www-project-api-security-testing-framework.git
 cd www-project-api-security-testing-framework
 mvn clean package -DskipTests
-java -jar target/api-security-testing-framework-2.0.0.jar -u https://api.example.com
+java -jar target/api-security-testing-framework-2.0.1.jar -u https://api.example.com
 ```
 
 For methodology — what to test, how to interpret results, how to avoid false positives — see the [Testing Guidelines](https://github.com/OWASP/www-project-api-security-testing-framework/blob/main/docs/TESTING_GUIDELINES.md). For full documentation see the [GitHub repository](https://github.com/OWASP/www-project-api-security-testing-framework).
@@ -82,10 +82,10 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
 
 ```yaml
 - name: Download ASTF
-  run: curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.0.jar
+  run: curl -LO https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest/download/astf-v2.0.1.jar
 
 - name: Run security scan
-  run: java -jar astf-v2.0.0.jar -u ${{ secrets.API_URL }} --token ${{ secrets.API_TOKEN }} -f SARIF -o results.sarif
+  run: java -jar astf-v2.0.1.jar -u ${{ secrets.API_URL }} --token ${{ secrets.API_TOKEN }} -f SARIF -o results.sarif
 
 - name: Upload to Code Scanning
   uses: github/codeql-action/upload-sarif@v3
@@ -129,6 +129,9 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
   authorization testing, mutual TLS/LLM/general-injection/ReDoS coverage, GraphQL depth,
   and live-verified findings against real vulnerable applications since v1.0.0
 - Comprehensive Testing Guidelines and a full documentation refresh
+- **v2.0.1** — the v2.0.0 jar itself reported its own version as v1.0.0 in `--version`
+  output and in every generated report; fixed by resolving the version dynamically from the
+  build instead of a hardcoded literal, so this can't silently go stale at future releases
 
 ### 🔜 Phase 6 — Real-World Pen-Testing Utility (Planned)
 - **Multi-step business-logic flow testing** — chained requests where a vulnerable endpoint

--- a/info.md
+++ b/info.md
@@ -1,17 +1,18 @@
 ### API Security Testing Framework Information
 * [Incubator Project](https://owasp.org/projects/)
 * [Tool Project](#)
-* [Version 2.0.0](#)
+* [Version 2.0.1](#)
 * [Builder](#)
 * [Breaker](#)
 
 ### Downloads or Social Links
-* [Download v2.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)
+* [Download v2.0.1](https://github.com/OWASP/www-project-api-security-testing-framework/releases/latest)
 * [GitHub](https://github.com/OWASP/www-project-api-security-testing-framework)
 
 ### Code Repository
 * [repo](https://github.com/OWASP/www-project-api-security-testing-framework)
 
 ### Change Log
+* [v2.0.1](https://github.com/OWASP/www-project-api-security-testing-framework/releases/tag/v2.0.1)
 * [v2.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/tag/v2.0.0)
 * [v1.0.0](https://github.com/OWASP/www-project-api-security-testing-framework/releases/tag/v1.0.0)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.owasp</groupId>
     <artifactId>api-security-testing-framework</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>jar</packaging>
 
     <name>OWASP API Security Testing Framework</name>


### PR DESCRIPTION
## Summary

Patch release to ship the dynamic-version-resolution fix (#108, already on `main`) in an actual downloadable JAR. `v2.0.0` is already tagged and live, and it prints its own version as `v1.0.0` — per this project's own TROUBLESHOOTING.md guidance, a tag that already published a real release shouldn't be retagged in place, so this ships as a proper `v2.0.1` patch instead.

- `pom.xml`: `2.0.0` → `2.0.1`
- `README.md` / `index.md` / `info.md` / `docs/TROUBLESHOOTING.md`: all "current release" jar-name/tag examples bumped to `v2.0.1`, keeping `v2.0.0`/`v1.0.0` as the historical changelog/roadmap entries they actually are
- `index.md` roadmap: added a line under Phase 5 documenting what this patch fixes, rather than silently incrementing the number with no trace of why

## Test plan

- [x] 352/352 tests passing
- [x] Verified against the built jar: `java -jar api-security-testing-framework-2.0.1.jar -V` → `OWASP API Security Testing Framework v2.0.1`

Once merged, I'll tag `v2.0.1` and push it to trigger the release workflow.