### PR TITLE
docs: add testable LLM Top 10 subset as a planned Phase 6 item

### DIFF
--- a/index.md
+++ b/index.md
@@ -139,6 +139,13 @@ Add ASTF to your GitHub Actions pipeline to scan on every pull request:
   BOLA, only discoverable through a link embedded in a prior response)
 - **Plugin system for custom test cases** — let the community publish and share their own
   checks without needing a core-repo review cycle for every addition
+- **Testable subset of the OWASP Top 10 for LLM Applications** — sensitive information
+  disclosure via LLM output (system-prompt leakage, cross-session data leakage), insecure
+  output handling (unsanitized LLM output reflected downstream), and LLM-specific resource
+  exhaustion, extending the existing prompt-injection check into the vulnerability classes
+  an HTTP-request-based scanner can actually reach. Deliberately excluded: training data
+  poisoning, supply-chain/SBOM analysis, and model theft — none are testable by sending API
+  requests, regardless of how good the scanner is
 - OpenAPI/Swagger and GraphQL SDL spec import for precise, guess-free endpoint/schema
   targeting instead of pattern-guessed discovery
 - Automated login-flow support — configure a credential-submission sequence once instead of


### PR DESCRIPTION
## Summary
- Adds one honest, clearly-"planned" roadmap line to Phase 6 covering the subset of the OWASP Top 10 for LLM Applications that a black-box HTTP-request scanner can actually test: sensitive information disclosure via LLM output, insecure output handling, and LLM-specific resource exhaustion.
- Explicitly names what's out of scope (training data poisoning, supply-chain/SBOM analysis, model theft) since none of these are reachable by sending API requests, regardless of implementation quality.
- No claims about current capability — the existing `ASTF-LLM-2023` (prompt injection) description elsewhere on the page is untouched since it's already accurate.

## Why
Sets a public marker of direction, useful groundwork if we pursue cross-referencing with the OWASP Top 10 for LLM Applications project later, without overclaiming anything not yet built.