### PR TITLE
docs: add Vivek Dhaduvai as project maintainer

### DIFF
--- a/index.md
+++ b/index.md
@@ -178,3 +178,8 @@ This project is licensed under the [Apache 2.0 License](https://www.apache.org/l
 
 - [Govindarajan Lakshmikanthan](mailto:govindarajan.lakshmikanthan@owasp.org) — Project Leader
   - GitHub: [@GovindarajanL](https://github.com/GovindarajanL)
+
+## Maintainers
+
+- Vivek Dhaduvai — Project Maintainer
+  - GitHub: [@dhaduvaivivek](https://github.com/dhaduvaivivek)


### PR DESCRIPTION
## Summary
- Adds a new "Maintainers" section to index.md, separate from "Project Leaders", listing Vivek Dhaduvai ([@dhaduvaivivek](https://github.com/dhaduvaivivek)) — confirmed on the repo's GitHub contributor list.
- Kept distinct from "Project Leaders" since that's the OWASP-recognized leadership designation and he has write/maintain access but isn't an OWASP Leader.